### PR TITLE
stop exchange blocker when no events

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -32,7 +32,8 @@ jobs:
           override: true
       - uses: actions-rs/cargo@v1
         with:
-          command: test --release
+          command: test
+          args: --release
 
   fmt:
     name: Rustfmt

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -1,6 +1,6 @@
 name: Rust
 
-on: [push, pull_request]
+on: [pull_request]
 
 env:
   CARGO_TERM_COLOR: always
@@ -32,7 +32,7 @@ jobs:
           override: true
       - uses: actions-rs/cargo@v1
         with:
-          command: test
+          command: test --release
 
   fmt:
     name: Rustfmt

--- a/src/core/exchanges/exchange_blocker.rs
+++ b/src/core/exchanges/exchange_blocker.rs
@@ -13,7 +13,7 @@ use std::iter::FromIterator;
 use std::ops::{Deref, DerefMut};
 use std::sync::Arc;
 use std::{fmt, iter};
-use tokio::sync::{mpsc, oneshot, Notify};
+use tokio::sync::{mpsc, Notify};
 use tokio::task::JoinHandle;
 use tokio::time::{sleep_until, Duration, Instant};
 
@@ -192,7 +192,7 @@ struct ProcessingCtx {
 }
 
 struct ExchangeBlockerEventsProcessor {
-    finished: Mutex<Option<oneshot::Receiver<()>>>,
+    processing_handle: Mutex<Option<JoinHandle<()>>>,
     handlers: BlockerEventHandlerVec,
     cancellation_token: CancellationToken,
 }
@@ -211,11 +211,10 @@ impl ExchangeBlockerEventsProcessor {
             cancellation_token: cancellation_token.clone(),
         };
 
-        let (finish_sender, finish_receiver) = oneshot::channel();
-        let _ = tokio::spawn(Self::processing(events_receiver, finish_sender, ctx));
+        let processing_handle = tokio::spawn(Self::processing(events_receiver, ctx));
 
         let events_processor = ExchangeBlockerEventsProcessor {
-            finished: Mutex::new(Some(finish_receiver)),
+            processing_handle: Mutex::new(Some(processing_handle)),
             handlers,
             cancellation_token,
         };
@@ -249,7 +248,6 @@ impl ExchangeBlockerEventsProcessor {
 
     async fn processing(
         mut events_receiver: mpsc::Receiver<ExchangeBlockerInternalEvent>,
-        finish_sender: oneshot::Sender<()>,
         mut ctx: ProcessingCtx,
     ) {
         while !ctx.cancellation_token.check_cancellation_requested() {
@@ -268,7 +266,6 @@ impl ExchangeBlockerEventsProcessor {
         events_receiver.close();
 
         trace!("ExchangeBlocker event processing is cancelled");
-        let _ = finish_sender.send(());
     }
 
     fn move_next_blocker_state_if_can(
@@ -386,7 +383,9 @@ impl ExchangeBlockerEventsProcessor {
 
     async fn stop_processing(&self) {
         self.cancellation_token.cancel();
-        let finished_rx = match self.finished.lock().take() {
+        tokio::task::yield_now().await;
+
+        let processing_handle = match self.processing_handle.lock().take() {
             None => {
                 trace!("ExchangeBlocker::stop_processing() called more then 1 time");
                 return;
@@ -395,7 +394,16 @@ impl ExchangeBlockerEventsProcessor {
         };
 
         trace!("ExchangeBlocker::stop_processing waiting for completion of processing");
-        let _ = finished_rx.await;
+        processing_handle.abort();
+        let res = processing_handle.await;
+        if let Err(join_err) = res {
+            if join_err.is_panic() {
+                error!(
+                    "We get panic in ExchangeBlockerEventsProcessor::processing(): {}",
+                    join_err
+                )
+            }
+        }
     }
 }
 
@@ -620,9 +628,22 @@ impl ExchangeBlocker {
         trace!("Unblock started {} {}", exchange_account_id, reason);
 
         let blocker_id = BlockerId::new(exchange_account_id.clone(), reason);
-        blocker_progress_apply_fn(&self.blockers, &blocker_id, |statuses| {
-            statuses.is_unblock_requested = true;
-        });
+
+        {
+            let read_guard = self.blockers.read();
+            let blocker = match read_guard
+                .get(&blocker_id.exchange_account_id)
+                .expect(EXPECTED_EAI_SHOULD_BE_CREATED)
+                .get(&blocker_id.reason)
+            {
+                Some(blocker) => blocker,
+                None => return,
+            };
+
+            let mut lock_guard = blocker.progress_state.lock();
+            let progress_state = lock_guard.deref_mut();
+            progress_state.is_unblock_requested = true;
+        }
 
         let event = ExchangeBlockerInternalEvent {
             blocker_id,
@@ -726,7 +747,7 @@ mod tests {
         BlockReason, ExchangeBlocker, ExchangeBlockerMoment,
     };
     use crate::core::nothing_to_do;
-    use futures::future::join_all;
+    use futures::future::{join, join_all};
     use futures::FutureExt;
     use parking_lot::Mutex;
     use rand::Rng;
@@ -734,7 +755,7 @@ mod tests {
     use std::ops::DerefMut;
     use std::sync::Arc;
     use std::time::Instant;
-    use tokio::sync::oneshot;
+    use tokio::sync::{oneshot, Notify};
     use tokio::time::{sleep, Duration};
 
     type Signal<T> = Arc<Mutex<T>>;
@@ -981,6 +1002,17 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn stop_blocker() {
+        let exchange_blocker = exchange_blocker();
+
+        let max_timeout = Duration::from_millis(100);
+        tokio::select! {
+            _ = exchange_blocker.stop_blocker() => nothing_to_do(),
+            _ = sleep(max_timeout) => panic!("Timeout was exceeded ({} ms)", max_timeout.as_millis()),
+        }
+    }
+
+    #[tokio::test]
     async fn block_with_handler_after_stop() {
         let exchange_blocker = exchange_blocker();
         let times_count = &Signal::<u8>::default();
@@ -1126,30 +1158,50 @@ mod tests {
         }
 
         let exchange_blocker = &exchange_blocker();
-        let (stop_blocker_tx, stop_blocker_rx) = oneshot::channel();
+        let (blocker_stop_started_tx, blocker_stop_started_rx) = oneshot::channel();
+        let (blocker_stopped_tx, blocker_stopped_rx) = oneshot::channel();
+        let spawn_actions_notify = Arc::new(Notify::new());
 
         {
             let exchange_blocker = exchange_blocker.clone();
             let _ = tokio::spawn(async move {
-                sleep(Duration::from_millis(10)).await;
+                sleep(Duration::from_millis(1)).await;
+                let _ = blocker_stop_started_tx.send(());
                 exchange_blocker.stop_blocker().await;
-                stop_blocker_tx.send(())
+                let _ = blocker_stopped_tx.send(());
             });
         }
 
-        const TIMES_COUNT: u32 = 200;
-        const REASONS_COUNT: u32 = 10;
-        for i in 0..TIMES_COUNT {
-            tokio::spawn(do_action(i % REASONS_COUNT, exchange_blocker.clone()));
-            if i % REASONS_COUNT == 0 {
-                tokio::task::yield_now().await;
-            }
+        {
+            let exchange_blocker = exchange_blocker.clone();
+            let spawn_actions_notify = spawn_actions_notify.clone();
+            let _ = tokio::spawn(async move {
+                const TIMES_COUNT: u32 = 1000;
+                const REASONS_COUNT: u32 = 10;
+                for i in 0..TIMES_COUNT {
+                    tokio::spawn(do_action(i % REASONS_COUNT, exchange_blocker.clone()));
+                    if i % REASONS_COUNT == 0 {
+                        tokio::task::yield_now().await;
+                    }
+                }
+
+                spawn_actions_notify.notify_waiters();
+            });
+        };
+
+        {
+            let spawn_actions_notify = spawn_actions_notify.clone();
+            let _ = tokio::spawn(async move {
+                tokio::select! {
+                    _ = spawn_actions_notify.notified() => panic!("spawn_actions finished before exchange blocker_block() started. It does not meet test case."),
+                    _ = blocker_stop_started_rx => nothing_to_do(),
+                }
+            });
         }
-        tokio::task::yield_now().await;
 
         let max_timeout = Duration::from_secs(2);
         tokio::select! {
-            _ = stop_blocker_rx => nothing_to_do(),
+            _ = join(spawn_actions_notify.notified(), blocker_stopped_rx) => nothing_to_do(),
             _ = sleep(max_timeout) => panic!("Timeout was exceeded ({} ms)", max_timeout.as_millis()),
         }
     }


### PR DESCRIPTION
fixed #27 

- fixed stopping ExchangeBlocker when no input no calls of methods block and unblock
- added new tests
- changed CI test command to run in release mode
- removed run CI on every push