### PR TITLE
Some fixes and improvements for ConnectivityManager

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -346,17 +346,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
-name = "async-channel"
-version = "1.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59740d83946db6a5af71ae25ddf9562c2b176b2ca42cf99a455f09f4a220d6b9"
-dependencies = [
- "concurrent-queue",
- "event-listener",
- "futures-core",
-]
-
-[[package]]
 name = "async-stream"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -500,12 +489,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cache-padded"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "631ae5198c9be5e753e5cc215e1bd73c2b466a3565173db433f52bb9d3e66dba"
-
-[[package]]
 name = "cc"
 version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -544,15 +527,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 dependencies = [
  "bitflags",
-]
-
-[[package]]
-name = "concurrent-queue"
-version = "1.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30ed07550be01594c6026cff2a1d7fe9c8f683caa798e12b68694ac9e88286a3"
-dependencies = [
- "cache-padded",
 ]
 
 [[package]]
@@ -740,12 +714,6 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "event-listener"
-version = "2.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7531096570974c3a9dcf9e4b8e1cede1ec26cf5046219fb3b9d897503b9be59"
 
 [[package]]
 name = "fern"
@@ -1194,7 +1162,6 @@ dependencies = [
  "actix-web",
  "actix-web-actors",
  "anyhow",
- "async-channel",
  "async-trait",
  "awc",
  "bytes",
@@ -2013,9 +1980,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8190d04c665ea9e6b6a0dc45523ade572c088d2e6566244c1122671dbf4ae3a"
+checksum = "8d56477f6ed99e10225f38f9f75f872f29b8b8bd8c0b946f63345bb144e9eeda"
 dependencies = [
  "autocfg 1.0.1",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,6 @@ actix-web-actors = "4.0.0-beta.1"
 awc = "3.0.0-beta.1"
 
 futures = "0.3"
-async-channel = "1.5.1"
 
 smallstr = { version = "0.2.0", features = ["serde"]}
 

--- a/src/core/connectivity/connectivity_manager.rs
+++ b/src/core/connectivity/connectivity_manager.rs
@@ -14,12 +14,12 @@ use std::{
     borrow::Borrow,
     ops::DerefMut,
     sync::{
-        mpsc, // TODO change std::sync::mpsc to tokio::mpsc when it implement method try_recv()
-        mpsc::TryRecvError,
         Arc,
         Weak,
     },
 };
+use tokio::sync::{broadcast};
+use crate::core::exchanges::cancellation_token::CancellationToken;
 
 pub const MAX_RETRY_CONNECT_COUNT: u32 = 3;
 
@@ -46,13 +46,12 @@ impl WebSocketConnectivity {
 enum WebSocketState {
     Disconnected,
     Connecting {
-        finished_receiver: async_channel::Receiver<()>,
-        cancellation_sender: mpsc::Sender<()>,
+        finished_sender: broadcast::Sender<()>,
+        cancel_websocket_connecting: CancellationToken,
     },
     Connected {
         websocket_actor: Addr<WebSocketActor>,
-        finished_sender: async_channel::Sender<()>,
-        finished_receiver: async_channel::Receiver<()>,
+        finished_sender: broadcast::Sender<()>,
     },
 }
 
@@ -176,26 +175,25 @@ impl ConnectivityManager {
     async fn disconnect_for_websocket(websocket_connectivity: &Mutex<WebSocketConnectivity>) {
         let guard = websocket_connectivity.lock();
 
-        let finished_receiver = match &guard.state {
+        let mut finished_receiver = match &guard.state {
             Disconnected => {
                 return;
             }
 
             WebSocketState::Connecting {
-                cancellation_sender,
-                finished_receiver,
+                cancel_websocket_connecting,
+                finished_sender,
             } => {
-                let _ = cancellation_sender.clone().send(());
-                finished_receiver.clone()
+                cancel_websocket_connecting.cancel();
+                finished_sender.subscribe()
             }
             WebSocketState::Connected {
                 websocket_actor,
-                finished_receiver,
-                ..
+                finished_sender,
             } => {
                 if websocket_actor.connected() {
                     let _ = websocket_actor.try_send(ForceClose);
-                    finished_receiver.clone()
+                    finished_sender.subscribe()
                 } else {
                     return;
                 }
@@ -235,11 +233,11 @@ impl ConnectivityManager {
     }
 
     fn set_disconnected_state(
-        finished_sender: async_channel::Sender<()>,
+        finished_sender: broadcast::Sender<()>,
         websocket_connectivity: &Mutex<WebSocketConnectivity>,
     ) {
         websocket_connectivity.lock().deref_mut().state = WebSocketState::Disconnected;
-        let _ = finished_sender.try_send(());
+        let _ = finished_sender.send(());
     }
 
     pub fn notify_connection_closed(&self, websocket_role: WebSocketRole) {
@@ -253,7 +251,7 @@ impl ConnectivityManager {
                     ..
                 } = websocket_state_guard.borrow().state
                 {
-                    let _ = finished_sender.try_send(());
+                    let _ = finished_sender.send(()).expect("Can't send finish message in ConnectivityManager::notify_connection_closed");
                 }
             }
 
@@ -264,29 +262,29 @@ impl ConnectivityManager {
     }
 
     pub async fn open_websocket_connection(self: &Arc<Self>, role: WebSocketRole) -> bool {
-        let (finished_sender, finished_receiver) = async_channel::bounded(1);
+        let (finished_sender, _) = broadcast::channel(50);
 
-        let (cancellation_sender, cancellation_receiver) = mpsc::channel();
+        let cancel_websocket_connecting = CancellationToken::new();
 
         let websocket_connectivity = self.websockets.get_websocket_state(role);
 
         {
             websocket_connectivity.lock().deref_mut().state = WebSocketState::Connecting {
-                finished_receiver: finished_receiver.clone(),
-                cancellation_sender,
+                finished_sender: finished_sender.clone(),
+                cancel_websocket_connecting: cancel_websocket_connecting.clone(),
             };
         }
 
         let mut attempt = 0;
 
-        while let Err(TryRecvError::Empty) = cancellation_receiver.try_recv() {
+        while !cancel_websocket_connecting.check_cancellation_requested() {
             trace!(
                 "Getting WebSocket parameters for {}",
                 self.exchange_account_id.clone()
             );
             let params = self.try_get_websocket_params(role).await;
             if let Some(params) = params {
-                if let Ok(()) = cancellation_receiver.try_recv() {
+                if cancel_websocket_connecting.check_cancellation_requested() {
                     return false;
                 }
 
@@ -303,7 +301,6 @@ impl ConnectivityManager {
                     websocket_connectivity.lock().deref_mut().state = WebSocketState::Connected {
                         websocket_actor,
                         finished_sender: finished_sender.clone(),
-                        finished_receiver: finished_receiver.clone(),
                     };
 
                     if attempt > 0 {
@@ -313,7 +310,7 @@ impl ConnectivityManager {
                         );
                     }
 
-                    if let Ok(()) = cancellation_receiver.try_recv() {
+                    if cancel_websocket_connecting.check_cancellation_requested() {
                         if let WebSocketState::Connected {
                             websocket_actor, ..
                         } = &websocket_connectivity.lock().borrow().state
@@ -327,10 +324,9 @@ impl ConnectivityManager {
 
                 attempt += 1;
 
-                let log_level = if attempt < MAX_RETRY_CONNECT_COUNT {
-                    Level::Warn
-                } else {
-                    Level::Error
+                let log_level = match attempt < MAX_RETRY_CONNECT_COUNT {
+                    true  => Level::Warn,
+                    false => Level::Error,
                 };
                 log!(
                     log_level,
@@ -494,7 +490,7 @@ mod tests {
             "we should reconnect expected count times"
         );
 
-        let _ = finish_sender.send(());
+        let _ = finish_sender.send(()).expect("in test");
 
         tokio::select! {
             _ = finish_receiver => info!("Test finished successfully"),

--- a/src/core/connectivity/connectivity_manager.rs
+++ b/src/core/connectivity/connectivity_manager.rs
@@ -1,3 +1,4 @@
+use crate::core::exchanges::cancellation_token::CancellationToken;
 use crate::core::{
     connectivity::{
         connectivity_manager::WebSocketState::Disconnected,
@@ -13,13 +14,9 @@ use std::pin::Pin;
 use std::{
     borrow::Borrow,
     ops::DerefMut,
-    sync::{
-        Arc,
-        Weak,
-    },
+    sync::{Arc, Weak},
 };
-use tokio::sync::{broadcast};
-use crate::core::exchanges::cancellation_token::CancellationToken;
+use tokio::sync::broadcast;
 
 pub const MAX_RETRY_CONNECT_COUNT: u32 = 3;
 
@@ -325,7 +322,7 @@ impl ConnectivityManager {
                 attempt += 1;
 
                 let log_level = match attempt < MAX_RETRY_CONNECT_COUNT {
-                    true  => Level::Warn,
+                    true => Level::Warn,
                     false => Level::Error,
                 };
                 log!(

--- a/src/core/exchanges/cancellation_token.rs
+++ b/src/core/exchanges/cancellation_token.rs
@@ -28,6 +28,7 @@ impl CancellationToken {
         state.signal.notify_waiters();
     }
 
+    /// Returns true if cancellation requested, otherwise false
     pub fn check_cancellation_requested(&self) -> bool {
         self.state.is_cancellation_requested.load(Ordering::SeqCst)
     }


### PR DESCRIPTION
- replaced `async-channel` with `tokio::sync::broadcast` (`async-channel` don't copy message for all existing receivers)
- using `CancellationToken` in `ConnectivityManager` as more appropriate instead of `std::sync::mpsc`
- updated tokio version