### PR TITLE
Added method `with_expect_args`

### DIFF
--- a/core/src/core/balance_manager/balance_manager.rs
+++ b/core/src/core/balance_manager/balance_manager.rs
@@ -24,7 +24,7 @@ use crate::core::service_configuration::configuration_descriptor::ConfigurationD
 use crate::core::DateTime;
 use crate::core::{balance_manager::balances::Balances, exchanges::common::ExchangeAccountId};
 
-use crate::core::infrastructure::WithExpectArgs;
+use crate::core::infrastructure::WithExpect;
 use anyhow::{bail, Context, Result};
 use futures::future::join_all;
 use itertools::Itertools;

--- a/core/src/core/balance_manager/balance_manager.rs
+++ b/core/src/core/balance_manager/balance_manager.rs
@@ -24,7 +24,7 @@ use crate::core::service_configuration::configuration_descriptor::ConfigurationD
 use crate::core::DateTime;
 use crate::core::{balance_manager::balances::Balances, exchanges::common::ExchangeAccountId};
 
-use crate::core::infrastructure::WithExpect;
+use crate::core::infrastructure::WithExpectArgs;
 use anyhow::{bail, Context, Result};
 use futures::future::join_all;
 use itertools::Itertools;
@@ -556,11 +556,12 @@ impl BalanceManager {
         configuration_descriptor: ConfigurationDescriptor,
         order_snapshot: &OrderSnapshot,
     ) {
-        let order_fill = order_snapshot
-            .fills
-            .fills
-            .last()
-            .with_expect(|| format!("failed to get fills from order {:?}", order_snapshot));
+        let order_fill = order_snapshot.fills.fills.last().with_expect_args(|f| {
+            f(&format_args!(
+                "failed to get fills from order {:?}",
+                order_snapshot
+            ))
+        });
 
         self.order_was_filled_with_fill(configuration_descriptor, order_snapshot, order_fill)
     }
@@ -761,11 +762,11 @@ impl BalanceManager {
     ) {
         self.balance_reservation_manager
             .approve_reservation(reservation_id, client_order_id, amount)
-            .with_expect(|| {
-                format!(
+            .with_expect_args(|f| {
+                f(&format_args!(
                     "failed to approve reservation {} {} {} ",
                     reservation_id, client_order_id, amount,
-                )
+                ))
             });
 
         self.save_balances();
@@ -1031,8 +1032,11 @@ impl BalanceManager {
                     let balances_and_positions = exchange
                         .get_balance(cancellation_token.clone())
                         .await
-                        .with_expect(|| {
-                            format!("failed to get balance for {}", exchange.exchange_account_id)
+                        .with_expect_args(|f| {
+                            f(&format_args!(
+                                "failed to get balance for {}",
+                                exchange.exchange_account_id
+                            ))
                         });
 
                     this.lock()

--- a/core/src/core/infrastructure.rs
+++ b/core/src/core/infrastructure.rs
@@ -487,6 +487,14 @@ pub trait WithExpect<T> {
 
     /// Unwrap the value or panic with additional context that is evaluated lazily
     /// The performance version. Double memory is not allocated for formatting
+    ///
+    /// # Examples
+    ///```should_panic
+    /// use mmb_core::core::infrastructure::WithExpect;
+    ///
+    /// let result: Result<(), ()> = Err(());
+    /// result.with_expect_args(|f| f(&format_args!("Error {}", "Message")));
+    /// ```
     fn with_expect_args(self, f: impl FnOnce(&dyn Fn(&Arguments))) -> T;
 }
 

--- a/core/tests/control_panel/statistics.rs
+++ b/core/tests/control_panel/statistics.rs
@@ -6,7 +6,6 @@ use mmb_core::core::disposition_execution::{PriceSlot, TradingContext};
 use mmb_core::core::exchanges::binance::binance::Binance;
 use mmb_core::core::explanation::Explanation;
 use mmb_core::core::lifecycle::cancellation_token::CancellationToken;
-use mmb_core::core::logger::init_logger;
 use mmb_core::core::order_book::local_snapshot_service::LocalSnapshotsService;
 use mmb_core::core::service_configuration::configuration_descriptor::ConfigurationDescriptor;
 use mmb_core::core::settings::BaseStrategySettings;


### PR DESCRIPTION
Added method `with_expect_args` as an optimized version of `with_expect` that doesn't recreate formatted string twice.