### PR TITLE
Fixed skipping cancel_order notification during graceful shutdown.

### DIFF
--- a/core/src/exchanges/general/exchange.rs
+++ b/core/src/exchanges/general/exchange.rs
@@ -291,14 +291,6 @@ impl Exchange {
     }
 
     fn on_websocket_message(&self, msg: &str) {
-        if self
-            .application_manager
-            .stop_token()
-            .is_cancellation_requested()
-        {
-            return;
-        }
-
         if self.exchange_client.should_log_message(msg) {
             self.log_websocket_message(msg);
         }


### PR DESCRIPTION

Decided that we should handle all websocket messages (at least on top level) at any time