### PR TITLE
Quick fix for panic logging in tests

### DIFF
--- a/core/src/balance_changes/profit_loss_stopper.rs
+++ b/core/src/balance_changes/profit_loss_stopper.rs
@@ -132,7 +132,7 @@ pub(crate) mod test {
     use std::sync::Arc;
 
     use chrono::Duration;
-    use mmb_utils::{infrastructure::init_infrastructure, DateTime};
+    use mmb_utils::{logger::init_logger_file_named, DateTime};
     use parking_lot::{Mutex, ReentrantMutexGuard};
     use rust_decimal_macros::dec;
 
@@ -325,7 +325,7 @@ pub(crate) mod test {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     pub async fn add_change_should_calculate_usd_correctly() {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let context = init(max_period(), 4);
 
         context
@@ -359,7 +359,7 @@ pub(crate) mod test {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     pub async fn add_change_should_ignore_old_data() {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let context = init(max_period(), 3);
 
         context
@@ -387,7 +387,7 @@ pub(crate) mod test {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     pub async fn check_for_limit_should_stop_transaction() {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let (mut exchange_blocker, exchange_blocker_locker) = ExchangeBlocker::init_mock();
         exchange_blocker
             .expect_block()
@@ -440,7 +440,7 @@ pub(crate) mod test {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     pub async fn check_for_limit_should_recover_after_positive_tarde() {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let (mut exchange_blocker, exchange_blocker_locker) = ExchangeBlocker::init_mock();
         exchange_blocker
             .expect_block()
@@ -517,7 +517,7 @@ pub(crate) mod test {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     pub async fn check_for_limit_should_recover_after_first_change_expired() {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let (mut exchange_blocker, exchange_blocker_locker) = ExchangeBlocker::init_mock();
         exchange_blocker
             .expect_block()
@@ -602,7 +602,7 @@ pub(crate) mod test {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     pub async fn check_for_limit_should_recover_after_time_period() {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let (mut exchange_blocker, exchange_blocker_locker) = ExchangeBlocker::init_mock();
         exchange_blocker
             .expect_block()

--- a/core/src/balance_manager/tests/balance_manager_derivative.rs
+++ b/core/src/balance_manager/tests/balance_manager_derivative.rs
@@ -228,7 +228,7 @@ mod tests {
 
     use chrono::Utc;
     use mmb_utils::hashmap;
-    use mmb_utils::infrastructure::init_infrastructure;
+    use mmb_utils::logger::init_logger_file_named;
     use parking_lot::RwLock;
     use rstest::rstest;
     use rust_decimal::Decimal;
@@ -347,7 +347,7 @@ mod tests {
 
     #[test]
     pub fn reservation_should_use_balance_currency() {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let test_object =
             create_test_obj_by_currency_code(BalanceManagerBase::eth(), dec!(100), false);
 
@@ -401,7 +401,7 @@ mod tests {
 
     #[test]
     pub fn reservation_should_use_balance_currency_reversed() {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let test_object =
             create_test_obj_by_currency_code(BalanceManagerBase::btc(), dec!(100), true);
 
@@ -465,7 +465,7 @@ mod tests {
         #[case] order_side: OrderSide,
         #[case] is_reversed: bool,
     ) {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let mut test_object =
             create_test_obj_by_currency_code(BalanceManagerBase::eth(), dec!(100), false);
 
@@ -517,7 +517,7 @@ mod tests {
         #[case] leverage: Option<Decimal>,
         #[case] is_reversed: bool,
     ) {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let mut test_object =
             create_test_obj_by_currency_code(BalanceManagerBase::eth(), dec!(100), is_reversed);
 
@@ -564,7 +564,7 @@ mod tests {
 
     #[test]
     pub fn fill_buy_should_commission_should_be_deducted_from_balance() {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let mut test_object =
             create_test_obj_by_currency_code(BalanceManagerBase::eth(), dec!(100), false);
 
@@ -618,7 +618,7 @@ mod tests {
 
     #[test]
     pub fn fill_buy_should_commission_should_be_deducted_from_balance_reversed() {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let mut test_object =
             create_test_obj_by_currency_code(BalanceManagerBase::btc(), dec!(100), true);
 
@@ -671,7 +671,7 @@ mod tests {
 
     #[test]
     pub fn fill_sell_should_commission_should_be_deducted_from_balance() {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let is_reversed = false;
         let mut test_object =
             create_test_obj_by_currency_code(BalanceManagerBase::eth(), dec!(100), is_reversed);
@@ -725,7 +725,7 @@ mod tests {
 
     #[test]
     pub fn fill_sell_should_commission_should_be_deducted_from_balance_reversed() {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let is_reversed = true;
         let mut test_object =
             create_test_obj_by_currency_code(BalanceManagerBase::btc(), dec!(100), is_reversed);
@@ -781,7 +781,7 @@ mod tests {
 
     #[test]
     pub fn reservation_after_fill_in_the_same_direction_buy_should_be_not_free() {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let is_reversed = false;
         let mut test_object =
             create_test_obj_by_currency_code(BalanceManagerBase::eth(), dec!(100), is_reversed);
@@ -895,7 +895,7 @@ mod tests {
 
     #[test]
     pub fn reservation_after_fill_in_the_same_direction_buy_should_be_not_free_reversed() {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let is_reversed = true;
         let mut test_object =
             create_test_obj_by_currency_code(BalanceManagerBase::btc(), dec!(100), is_reversed);
@@ -1011,7 +1011,7 @@ mod tests {
 
     #[test]
     pub fn reservation_after_fill_in_the_same_direction_sell_should_be_not_free() {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let is_reversed = false;
         let mut test_object =
             create_test_obj_by_currency_code(BalanceManagerBase::eth(), dec!(100), is_reversed);
@@ -1125,7 +1125,7 @@ mod tests {
 
     #[test]
     pub fn reservation_after_fill_in_the_same_direction_sell_should_be_not_free_reversed() {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let is_reversed = true;
         let mut test_object =
             create_test_obj_by_currency_code(BalanceManagerBase::btc(), dec!(100), is_reversed);
@@ -1241,7 +1241,7 @@ mod tests {
 
     #[test]
     pub fn reservation_after_fill_in_opposite_direction_buy_sell_should_be_partially_free() {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let is_reversed = false;
         let mut test_object =
             create_test_obj_by_currency_code(BalanceManagerBase::eth(), dec!(100), is_reversed);
@@ -1402,7 +1402,7 @@ mod tests {
     #[test]
     pub fn reservation_after_fill_in_opposite_direction_buy_sell_should_be_partially_free_reversed()
     {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let is_reversed = true;
         let mut test_object =
             create_test_obj_by_currency_code(BalanceManagerBase::btc(), dec!(100), is_reversed);
@@ -1564,7 +1564,7 @@ mod tests {
 
     #[test]
     pub fn reservation_after_fill_in_opposite_direction_sell_buy_should_be_partially_free() {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let is_reversed = false;
         let mut test_object =
             create_test_obj_by_currency_code(BalanceManagerBase::eth(), dec!(100), is_reversed);
@@ -1727,7 +1727,7 @@ mod tests {
     #[test]
     pub fn reservation_after_fill_in_opposite_direction_sell_buy_should_be_partially_free_reversed()
     {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let is_reversed = true;
         let mut test_object =
             create_test_obj_by_currency_code(BalanceManagerBase::btc(), dec!(100), is_reversed);
@@ -1896,7 +1896,7 @@ mod tests {
     ) {
         // This case may happen because parallel nature of handling orders
 
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let is_reversed = false;
         let mut test_object =
             create_test_obj_by_currency_code(BalanceManagerBase::eth(), dec!(10), is_reversed);
@@ -1968,7 +1968,7 @@ mod tests {
 
     #[test]
     pub fn clone_when_order_created() {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let is_reversed = false;
         let mut test_object =
             create_test_obj_by_currency_code(BalanceManagerBase::eth(), dec!(10), is_reversed);
@@ -2057,7 +2057,7 @@ mod tests {
         #[case] amount_2: Amount,
         #[case] amount_to_transfer: Amount,
     ) {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let is_reversed = false;
         let test_object = create_eth_btc_test_obj(src_balance, src_balance, is_reversed);
 
@@ -2154,7 +2154,7 @@ mod tests {
         #[case] amount_2: Amount,
         #[case] amount_to_transfer: Amount,
     ) {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let is_reversed = false;
         let test_object =
             create_test_obj_by_currency_code(BalanceManagerBase::eth(), src_balance, is_reversed);
@@ -2209,7 +2209,7 @@ mod tests {
     #[test]
     #[ignore] // Transfer
     pub fn transfer_reservations_amount_partial() {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let is_reversed = false;
         let test_object =
             create_test_obj_by_currency_code(BalanceManagerBase::eth(), dec!(30), is_reversed);
@@ -2268,7 +2268,7 @@ mod tests {
     #[test]
     #[ignore] // Transfer
     pub fn transfer_reservations_amount_partial_with_cost_diff_due_to_fill() {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let is_reversed = false;
         let mut test_object =
             create_test_obj_by_currency_code(BalanceManagerBase::eth(), dec!(25), is_reversed);
@@ -2393,7 +2393,7 @@ mod tests {
 
     #[test]
     pub fn update_exchange_balance_should_use_cost_for_balance_filter_when_no_free_cost() {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let is_reversed = false;
         let test_object =
             create_test_obj_by_currency_code(BalanceManagerBase::eth(), dec!(25), is_reversed);
@@ -2455,7 +2455,7 @@ mod tests {
 
     #[test]
     pub fn update_exchange_balance_should_use_cost_for_balance_filter_when_partially_free_cost() {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let is_reversed = false;
         let test_object = create_test_obj_by_currency_code_and_symbol_currency_pair(
             BalanceManagerBase::eth(),
@@ -2524,7 +2524,7 @@ mod tests {
 
     #[test]
     pub fn fills_and_reservations_no_limit_buy_enough_and_not_enough() {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let is_reversed = false;
         let mut test_object =
             create_test_obj_by_currency_code(BalanceManagerBase::eth(), dec!(0), is_reversed);
@@ -2594,7 +2594,7 @@ mod tests {
 
     #[test]
     pub fn fills_and_reservations_no_limit_buy_enough_and_not_enough_reversed() {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let is_reversed = true;
         let mut test_object =
             create_test_obj_by_currency_code(BalanceManagerBase::btc(), dec!(0), is_reversed);
@@ -2676,7 +2676,7 @@ mod tests {
 
     #[test]
     pub fn fills_and_reservations_no_limit_sell_enough_and_not_enough() {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let is_reversed = false;
         let mut test_object =
             create_test_obj_by_currency_code(BalanceManagerBase::eth(), dec!(0), is_reversed);
@@ -2746,7 +2746,7 @@ mod tests {
 
     #[test]
     pub fn fills_and_reservations_no_limit_sell_enough_and_not_enough_reversed() {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let is_reversed = true;
         let mut test_object =
             create_test_obj_by_currency_code(BalanceManagerBase::btc(), dec!(0), is_reversed);
@@ -2830,7 +2830,7 @@ mod tests {
 
     #[test]
     pub fn fills_and_reservations_limit_buy_enough_and_not_enough() {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let is_reversed = false;
         let mut test_object =
             create_test_obj_by_currency_code(BalanceManagerBase::eth(), dec!(0), is_reversed);
@@ -2970,7 +2970,7 @@ mod tests {
 
     #[test]
     pub fn fills_and_reservations_limit_buy_enough_and_not_enough_reversed() {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let is_reversed = true;
         let mut test_object =
             create_test_obj_by_currency_code(BalanceManagerBase::btc(), dec!(0), is_reversed);
@@ -3114,7 +3114,7 @@ mod tests {
 
     #[test]
     pub fn fills_and_reservations_limit_sell_enough_and_not_enough() {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let is_reversed = false;
         let mut test_object =
             create_test_obj_by_currency_code(BalanceManagerBase::eth(), dec!(0), is_reversed);
@@ -3276,7 +3276,7 @@ mod tests {
 
     #[test]
     pub fn fills_and_reservations_limit_sell_enough_and_not_enough_reversed() {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let is_reversed = true;
         let mut test_object =
             create_test_obj_by_currency_code(BalanceManagerBase::btc(), dec!(0), is_reversed);
@@ -3437,7 +3437,7 @@ mod tests {
 
     #[test]
     pub fn can_reserve_no_limit_enough_and_not_enough() {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let is_reversed = false;
         let mut test_object = create_test_obj_by_currency_code_and_symbol_currency_pair(
             BalanceManagerBase::eth(),
@@ -3495,7 +3495,7 @@ mod tests {
 
     #[test]
     pub fn can_reserve_no_limit_enough_and_not_enough_reversed() {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let is_reversed = true;
         let mut test_object = create_test_obj_by_currency_code_and_symbol_currency_pair(
             BalanceManagerBase::btc(),
@@ -3561,7 +3561,7 @@ mod tests {
 
     #[test]
     pub fn can_reserve_limit_enough_and_not_enough() {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let is_reversed = false;
         let mut test_object = create_test_obj_by_currency_code_and_symbol_currency_pair(
             BalanceManagerBase::eth(),
@@ -3620,7 +3620,7 @@ mod tests {
 
     #[test]
     pub fn can_reserve_limit_enough_and_not_enough_reversed() {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let is_reversed = true;
         let mut test_object = create_test_obj_by_currency_code_and_symbol_currency_pair(
             BalanceManagerBase::btc(),
@@ -3704,7 +3704,7 @@ mod tests {
         #[case] expected_can_reserve: bool,
         #[case] is_reversed: bool,
     ) {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let mut test_object = create_test_obj_by_currency_code_and_symbol_currency_pair(
             BalanceManagerBase::eth(),
             dec!(1000),
@@ -3738,7 +3738,7 @@ mod tests {
     #[test]
     pub fn get_leveraged_balance_in_amount_currency_code_balance_is_more_than_limit_long_position()
     {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let amount_limit = dec!(5);
         let is_reversed = false;
 
@@ -3798,7 +3798,7 @@ mod tests {
     #[test]
     pub fn get_leveraged_balance_in_amount_currency_code_balance_is_more_than_limit_long_position_reversed(
     ) {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let amount_limit = dec!(5) / BalanceManagerDerivative::price();
         let is_reversed = true;
 
@@ -3864,7 +3864,7 @@ mod tests {
     #[test]
     pub fn get_leveraged_balance_in_amount_currency_code_balance_is_more_than_limit_short_position()
     {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let amount_limit = dec!(5);
         let is_reversed = false;
 
@@ -3924,7 +3924,7 @@ mod tests {
     #[test]
     pub fn get_leveraged_balance_in_amount_currency_code_balance_is_more_than_limit_short_position_reversed(
     ) {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let amount_limit = dec!(5) / BalanceManagerDerivative::price();
         let is_reversed = true;
 
@@ -3990,7 +3990,7 @@ mod tests {
     #[test]
     pub fn get_leveraged_balance_in_amount_currency_code_balance_is_less_than_limit_long_position()
     {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let amount_limit = dec!(10);
         let is_reversed = false;
 
@@ -4057,7 +4057,7 @@ mod tests {
     #[test]
     pub fn get_leveraged_balance_in_amount_currency_code_balance_is_less_than_limit_long_position_reversed(
     ) {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let amount_limit = dec!(1000)
             / BalanceManagerDerivative::price()
             / BalanceManagerDerivative::reversed_amount_multiplier();
@@ -4134,7 +4134,7 @@ mod tests {
     #[test]
     pub fn get_leveraged_balance_in_amount_currency_code_balance_is_less_than_limit_short_position()
     {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let amount_limit = dec!(10);
         let is_reversed = false;
 
@@ -4200,7 +4200,7 @@ mod tests {
     #[test]
     pub fn get_leveraged_balance_in_amount_currency_code_balance_is_less_than_limit_short_position_reversed(
     ) {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let amount_limit = dec!(1000)
             / BalanceManagerDerivative::price()
             / BalanceManagerDerivative::reversed_amount_multiplier();
@@ -4276,7 +4276,7 @@ mod tests {
     #[test]
     pub fn get_leveraged_balance_in_amount_currency_code_max_rounding_error() {
         //real-life case with a rounding error https://github.com/CryptoDreamTeam/CryptoLp/issues/1348
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let amount_limit = dec!(30);
         let price = dec!(9341);
         let is_reversed = false;
@@ -4333,7 +4333,7 @@ mod tests {
     pub fn update_exchange_balance_should_restore_position_on_all_exchanges(
         #[case] is_reversed: bool,
     ) {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let position = dec!(2);
 
         let test_object = create_test_obj_by_currency_code_and_symbol_currency_pair(
@@ -4383,7 +4383,7 @@ mod tests {
     pub fn update_exchange_balance_should_change_fill_position_only_on_first_update(
         #[case] is_reversed: bool,
     ) {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let position = dec!(2);
 
         let test_object = create_test_obj_by_currency_code_and_symbol_currency_pair(
@@ -4433,7 +4433,7 @@ mod tests {
     #[case(true)]
     #[case(false)]
     pub fn reservation_over_limit_should_return_false_on_try_reserve(#[case] is_reversed: bool) {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let amount_limit = dec!(2);
 
         let mut test_object = create_test_obj_by_currency_code_and_symbol_currency_pair(

--- a/core/src/balance_manager/tests/balance_manager_ordinal.rs
+++ b/core/src/balance_manager/tests/balance_manager_ordinal.rs
@@ -150,7 +150,7 @@ mod tests {
 
     use chrono::Utc;
     use mmb_utils::hashmap;
-    use mmb_utils::infrastructure::init_infrastructure;
+    use mmb_utils::logger::init_logger_file_named;
     use parking_lot::{Mutex, RwLock};
     use rstest::rstest;
     use rust_decimal::Decimal;
@@ -289,7 +289,7 @@ mod tests {
 
     #[test]
     pub fn balance_was_received_not_existing_exchange_account_id() {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let test_object = BalanceManagerOrdinal::new();
         assert_eq!(
             test_object
@@ -301,7 +301,7 @@ mod tests {
 
     #[test]
     pub fn balance_was_received_existing_exchange_account_id_without_currency() {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let test_object = BalanceManagerOrdinal::new();
         assert_eq!(
             test_object
@@ -313,7 +313,7 @@ mod tests {
 
     #[test]
     pub fn balance_was_received_existing_exchange_account_id_with_currency() {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let test_object = create_test_obj_by_currency_code(BalanceManagerBase::btc(), dec!(2));
 
         assert!(test_object
@@ -324,7 +324,7 @@ mod tests {
     #[test]
     pub fn update_exchange_balance_skip_currencies_with_zero_balance_which_are_not_part_of_currency_pairs(
     ) {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let test_object = BalanceManagerOrdinal::new();
 
         let exchange_account_id = test_object.balance_manager_base.exchange_account_id_1;
@@ -383,7 +383,7 @@ mod tests {
 
     #[test]
     pub fn get_balance_buy_returns_quote_balance_and_currency_code() {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let test_object = create_eth_btc_test_obj(dec!(0.5), dec!(0.1));
         let exchange_account_id = test_object.balance_manager_base.exchange_account_id_1;
 
@@ -417,7 +417,7 @@ mod tests {
 
     #[test]
     pub fn get_balance_sell_return_base_balance_and_currency_code() {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let test_object = create_eth_btc_test_obj(dec!(0.5), dec!(0.1));
         let exchange_account_id = test_object.balance_manager_base.exchange_account_id_1;
 
@@ -451,7 +451,7 @@ mod tests {
 
     #[test]
     pub fn can_reserve_buy_not_enough_balance() {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let test_object = create_test_obj_by_currency_code(BalanceManagerBase::btc(), dec!(0.5));
 
         let reserve_parameters = test_object.balance_manager_base.create_reserve_parameters(
@@ -477,7 +477,7 @@ mod tests {
 
     #[test]
     pub fn can_reserve_buy_enough_balance() {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let test_object = create_test_obj_by_currency_code(BalanceManagerBase::btc(), dec!(1.0));
 
         let reserve_parameters = test_object.balance_manager_base.create_reserve_parameters(
@@ -500,7 +500,7 @@ mod tests {
 
     #[test]
     pub fn can_reserve_sell_not_enough_balance() {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let test_object = create_test_obj_by_currency_code(BalanceManagerBase::eth(), dec!(0.5));
 
         let reserve_parameters = test_object.balance_manager_base.create_reserve_parameters(
@@ -526,7 +526,7 @@ mod tests {
 
     #[test]
     pub fn can_reserve_sell_enough_balance() {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let test_object = create_test_obj_by_currency_code(BalanceManagerBase::eth(), dec!(5.0));
 
         let reserve_parameters = test_object.balance_manager_base.create_reserve_parameters(
@@ -549,7 +549,7 @@ mod tests {
 
     #[test]
     pub fn try_reserve_buy_not_enough_balance() {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let test_object = create_test_obj_by_currency_code(BalanceManagerBase::btc(), dec!(0.5));
 
         let reserve_parameters = test_object
@@ -571,7 +571,7 @@ mod tests {
 
     #[test]
     pub fn try_reserve_buy_enough_balance() {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let test_object = create_test_obj_by_currency_code(BalanceManagerBase::btc(), dec!(1));
 
         let reserve_parameters = test_object
@@ -612,7 +612,7 @@ mod tests {
 
     #[test]
     pub fn try_reserve_sell_not_enough_balance() {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let test_object = create_test_obj_by_currency_code(BalanceManagerBase::eth(), dec!(0.5));
 
         let reserve_parameters = test_object
@@ -634,7 +634,7 @@ mod tests {
 
     #[test]
     pub fn try_reserve_sell_enough_balance() {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let test_object = create_test_obj_by_currency_code(BalanceManagerBase::eth(), dec!(5));
 
         let reserve_parameters = test_object
@@ -674,7 +674,7 @@ mod tests {
 
     #[test]
     pub fn try_update_reservation_buy_worse_price_not_enough_balance() {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let test_object = create_test_obj_by_currency_code(BalanceManagerBase::btc(), dec!(1.1));
 
         let reserve_parameters = test_object
@@ -708,7 +708,7 @@ mod tests {
 
     #[test]
     pub fn try_update_reservation_buy_worse_price_enough_balance() {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let test_object = create_test_obj_by_currency_code(BalanceManagerBase::btc(), dec!(1.5));
 
         let reserve_parameters = test_object
@@ -739,7 +739,7 @@ mod tests {
 
     #[test]
     pub fn try_update_reservation_buy_better_price() {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let test_object = create_test_obj_by_currency_code(BalanceManagerBase::btc(), dec!(1.1));
 
         let reserve_parameters = test_object
@@ -776,7 +776,7 @@ mod tests {
 
     #[test]
     pub fn try_update_reservation_sell() {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let test_object = create_test_obj_by_currency_code(BalanceManagerBase::eth(), dec!(5.0));
 
         let reserve_parameters = test_object
@@ -806,7 +806,7 @@ mod tests {
 
     #[test]
     pub fn try_reserve_pair_not_enough_balance_for_1() {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let test_object = create_eth_btc_test_obj(dec!(0.0), dec!(5));
 
         let reserve_parameters_1 = test_object
@@ -841,7 +841,7 @@ mod tests {
 
     #[test]
     pub fn try_reserve_pair_not_enough_balance_for_2() {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let test_object = create_eth_btc_test_obj(dec!(3), dec!(0));
 
         let reserve_parameters_1 = test_object
@@ -876,7 +876,7 @@ mod tests {
 
     #[test]
     pub fn try_reserve_pair_enough_balance() {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let test_object = create_eth_btc_test_obj(dec!(1), dec!(5));
 
         let reserve_parameters_1 = test_object
@@ -946,7 +946,7 @@ mod tests {
 
     #[test]
     pub fn try_reserve_three_not_enough_balance_for_1() {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let test_object = create_eth_btc_test_obj(dec!(0.0), dec!(5));
 
         let reserve_parameters_1 = test_object
@@ -990,7 +990,7 @@ mod tests {
 
     #[test]
     pub fn try_reserve_three_not_enough_balance_for_2() {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let test_object = create_eth_btc_test_obj(dec!(1), dec!(5));
 
         let reserve_parameters_1 = test_object
@@ -1034,7 +1034,7 @@ mod tests {
 
     #[test]
     pub fn try_reserve_three_not_enough_balance_for_3() {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let test_object = create_eth_btc_test_obj(dec!(1), dec!(5));
 
         let reserve_parameters_1 = test_object
@@ -1077,7 +1077,7 @@ mod tests {
 
     #[test]
     pub fn try_reserve_three_enough_balance() {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let test_object = create_eth_btc_test_obj(dec!(1), dec!(6));
 
         let reserve_parameters_1 = test_object
@@ -1181,7 +1181,7 @@ mod tests {
 
     #[test]
     pub fn unreserve_should_not_unreserve_for_unknown_exchange_account_id() {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let test_object = create_test_obj_by_currency_code(BalanceManagerBase::btc(), dec!(1));
 
         let reserve_parameters = test_object
@@ -1213,7 +1213,7 @@ mod tests {
 
     #[test]
     pub fn unreserve_can_unreserve_more_than_reserved_with_compensation_amounts() {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let test_object = create_test_obj_by_currency_code(BalanceManagerBase::btc(), dec!(1));
 
         let reserve_parameters = test_object
@@ -1246,7 +1246,7 @@ mod tests {
 
     #[test]
     pub fn unreserve_can_not_unreserve_after_complete_unreserved() {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let test_object = create_test_obj_by_currency_code(BalanceManagerBase::btc(), dec!(1));
 
         let reserve_parameters = test_object
@@ -1287,7 +1287,7 @@ mod tests {
     // min positive value in rust_decimaL::Decimal (Scale maximum precision - 28)
     #[case(dec!(1e-28))]
     pub fn unreserve_zero_amount(#[case] amount_to_unreserve: Amount) {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let test_object = create_test_obj_by_currency_code(BalanceManagerBase::eth(), dec!(5));
 
         let symbol = Arc::from(Symbol::new(
@@ -1350,7 +1350,7 @@ mod tests {
 
     #[test]
     pub fn unreserve_buy() {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let test_object = create_test_obj_by_currency_code(BalanceManagerBase::btc(), dec!(1));
 
         let reserve_parameters = test_object
@@ -1383,7 +1383,7 @@ mod tests {
 
     #[test]
     pub fn unreserve_sell() {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let test_object = create_test_obj_by_currency_code(BalanceManagerBase::eth(), dec!(5));
 
         let reserve_parameters = test_object
@@ -1416,7 +1416,7 @@ mod tests {
 
     #[test]
     pub fn unreserve_rest_buy() {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let test_object = create_test_obj_by_currency_code(BalanceManagerBase::btc(), dec!(1));
 
         let reserve_parameters = test_object
@@ -1449,7 +1449,7 @@ mod tests {
 
     #[test]
     pub fn unreserve_rest_sell() {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let test_object = create_test_obj_by_currency_code(BalanceManagerBase::eth(), dec!(5));
 
         let reserve_parameters = test_object
@@ -1482,7 +1482,7 @@ mod tests {
 
     #[test]
     pub fn unreserve_rest_partially_unreserved_buy() {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let test_object = create_test_obj_by_currency_code(BalanceManagerBase::btc(), dec!(1));
 
         let reserve_parameters = test_object
@@ -1520,7 +1520,7 @@ mod tests {
 
     #[test]
     pub fn unreserve_rest_partially_unreserved_sell() {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let test_object = create_test_obj_by_currency_code(BalanceManagerBase::eth(), dec!(5));
 
         let reserve_parameters = test_object
@@ -1567,7 +1567,7 @@ mod tests {
         #[case] amount_2: Amount,
         #[case] amount_to_transfer: Amount,
     ) {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let test_object = create_eth_btc_test_obj(src_balance, src_balance);
 
         let side = OrderSide::Sell;
@@ -1642,7 +1642,7 @@ mod tests {
         #[case] amount_2: Amount,
         #[case] amount_to_transfer: Amount,
     ) {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let test_object = create_eth_btc_test_obj(src_balance, src_balance);
 
         let side = OrderSide::Buy;
@@ -1708,7 +1708,7 @@ mod tests {
 
     #[test]
     pub fn transfer_reservations_amount_partial() {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let test_object = create_test_obj_by_currency_code(BalanceManagerBase::eth(), dec!(5));
 
         let reserve_parameters_1 = test_object
@@ -1760,7 +1760,7 @@ mod tests {
 
     #[test]
     pub fn transfer_reservations_amount_all() {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let test_object = create_test_obj_by_currency_code(BalanceManagerBase::eth(), dec!(5));
 
         let reserve_parameters_1 = test_object
@@ -1812,7 +1812,7 @@ mod tests {
 
     #[test]
     pub fn transfer_reservations_amount_more_than_we_have_should_do_nothing_and_panic() {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let test_object = Arc::new(Mutex::new(create_test_obj_by_currency_code(
             BalanceManagerBase::eth(),
             dec!(5),
@@ -1883,7 +1883,7 @@ mod tests {
 
     #[test]
     pub fn unreserve_zero_from_zero_reservation_should_remove_reservation() {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let test_object = create_test_obj_by_currency_code(BalanceManagerBase::eth(), dec!(5));
 
         let reserve_parameters = test_object
@@ -1909,7 +1909,7 @@ mod tests {
 
     #[test]
     pub fn transfer_reservations_amount_with_unreserve() {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let test_object = create_test_obj_by_currency_code(BalanceManagerBase::eth(), dec!(5));
 
         let reserve_parameters_1 = test_object
@@ -1968,7 +1968,7 @@ mod tests {
 
     #[test]
     pub fn transfer_reservations_amount_partial_approve() {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let mut test_object = create_test_obj_by_currency_code(BalanceManagerBase::eth(), dec!(5));
 
         let reserve_parameters_1 = test_object
@@ -2065,7 +2065,7 @@ mod tests {
     #[test]
     #[should_panic]
     pub fn transfer_reservations_amount_more_thane_we_have() {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let mut test_object = create_test_obj_by_currency_code(BalanceManagerBase::eth(), dec!(5));
 
         let reserve_parameters_1 = test_object
@@ -2122,7 +2122,7 @@ mod tests {
     #[test]
     #[should_panic]
     pub fn transfer_reservations_amount_more_than_we_have_by_approve_client_order_id() {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let mut test_object = create_test_obj_by_currency_code(BalanceManagerBase::eth(), dec!(5));
 
         let reserve_parameters_1 = test_object
@@ -2175,7 +2175,7 @@ mod tests {
     #[test]
     #[should_panic]
     pub fn transfer_reservations_unknown_client_order_id() {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let test_object = create_test_obj_by_currency_code(BalanceManagerBase::eth(), dec!(5));
 
         let reserve_parameters_1 = test_object
@@ -2205,7 +2205,7 @@ mod tests {
 
     #[test]
     pub fn transfer_reservations_amount_partial_approve_with_multiple_orders() {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let mut test_object = create_test_obj_by_currency_code(BalanceManagerBase::eth(), dec!(5));
 
         let reserve_parameters_1 = test_object
@@ -2294,7 +2294,7 @@ mod tests {
 
     #[test]
     pub fn transfer_reservations_amount_partial_approve_with_multiple_orders_to_existing_part() {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let mut test_object = create_test_obj_by_currency_code(BalanceManagerBase::eth(), dec!(5));
 
         let reserve_parameters_1 = test_object
@@ -2389,7 +2389,7 @@ mod tests {
 
     #[test]
     pub fn unreserve_pair() {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let test_object = create_eth_btc_test_obj_for_two_exchanges(
             BalanceManagerBase::btc(),
             dec!(1),
@@ -2456,7 +2456,7 @@ mod tests {
 
     #[test]
     pub fn get_balance_not_existing_exchange_account_id() {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let test_object = create_test_obj_by_currency_code(BalanceManagerBase::eth(), dec!(5));
 
         assert_eq!(
@@ -2476,7 +2476,7 @@ mod tests {
 
     #[test]
     pub fn get_balance_not_existing_currency_code() {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let test_object = create_test_obj_by_currency_code(BalanceManagerBase::btc(), dec!(2));
 
         assert_eq!(
@@ -2496,7 +2496,7 @@ mod tests {
 
     #[test]
     pub fn get_balance_unapproved_reservations_are_counted_even_after_balance_update() {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let test_object = BalanceManagerOrdinal::new();
 
         let exchange_account_id = test_object.balance_manager_base.exchange_account_id_1;
@@ -2561,7 +2561,7 @@ mod tests {
 
     #[test]
     pub fn get_balance_approved_reservations_are_not_counted_after_balance_update() {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let test_object = BalanceManagerOrdinal::new();
 
         let exchange_account_id = test_object.balance_manager_base.exchange_account_id_1;
@@ -2633,7 +2633,7 @@ mod tests {
 
     #[test]
     pub fn get_balance_partially_approved_reservations_are_not_counted_after_balance_update() {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let test_object = BalanceManagerOrdinal::new();
 
         let exchange_account_id = test_object.balance_manager_base.exchange_account_id_1;
@@ -2708,7 +2708,7 @@ mod tests {
 
     #[test]
     pub fn order_was_filled_last_fill_by_default_buy() {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let mut test_object = create_test_obj_with_multiple_currencies(
             vec![
                 BalanceManagerBase::btc(),
@@ -2769,7 +2769,7 @@ mod tests {
 
     #[test]
     pub fn order_was_filled_last_fill_by_default_sell() {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let mut test_object = create_test_obj_with_multiple_currencies(
             vec![
                 BalanceManagerBase::btc(),
@@ -2830,7 +2830,7 @@ mod tests {
 
     #[test]
     pub fn order_was_filled_specific_fill_buy() {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let mut test_object = create_test_obj_with_multiple_currencies(
             vec![
                 BalanceManagerBase::btc(),
@@ -2892,7 +2892,7 @@ mod tests {
 
     #[test]
     pub fn order_was_filled_specific_fill_sell() {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let mut test_object = create_test_obj_with_multiple_currencies(
             vec![
                 BalanceManagerBase::btc(),
@@ -2954,7 +2954,7 @@ mod tests {
 
     #[test]
     pub fn order_was_finished_buy() {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let mut test_object = create_test_obj_with_multiple_currencies(
             vec![
                 BalanceManagerBase::btc(),
@@ -3016,7 +3016,7 @@ mod tests {
 
     #[test]
     pub fn order_was_finished_sell() {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let mut test_object = create_test_obj_with_multiple_currencies(
             vec![
                 BalanceManagerBase::btc(),
@@ -3077,7 +3077,7 @@ mod tests {
 
     #[test]
     pub fn order_was_finished_buy_sell() {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let mut test_object = create_test_obj_with_multiple_currencies(
             vec![
                 BalanceManagerBase::btc(),
@@ -3161,7 +3161,7 @@ mod tests {
 
     #[test]
     pub fn clone_when_order_creating() {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let mut test_object = create_test_obj_with_multiple_currencies(
             vec![
                 BalanceManagerBase::eth(),
@@ -3266,7 +3266,7 @@ mod tests {
 
     #[test]
     pub fn clone_when_order_got_status_created_but_its_reservation_is_not_approved() {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let mut test_object = create_test_obj_with_multiple_currencies(
             vec![
                 BalanceManagerBase::eth(),
@@ -3377,7 +3377,7 @@ mod tests {
 
     #[test]
     pub fn clone_when_order_created() {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let mut test_object = create_test_obj_with_multiple_currencies(
             vec![
                 BalanceManagerBase::eth(),
@@ -3494,7 +3494,7 @@ mod tests {
 
     #[test]
     pub fn clone_when_exists_unapproved_reservations() {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let mut test_object = create_test_obj_with_multiple_currencies(
             vec![
                 BalanceManagerBase::eth(),
@@ -3601,7 +3601,7 @@ mod tests {
 
     #[test]
     pub fn clone_when_exists_approved_reservation() {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let mut test_object = create_test_obj_with_multiple_currencies(
             vec![
                 BalanceManagerBase::eth(),
@@ -3706,7 +3706,7 @@ mod tests {
     #[test]
     pub fn clone_when_exists_partially_approved_reservation_1_approved_part_out_of_1_and_no_created_orders(
     ) {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let mut test_object = create_test_obj_with_multiple_currencies(
             vec![
                 BalanceManagerBase::eth(),
@@ -3812,7 +3812,7 @@ mod tests {
     #[test]
     pub fn clone_when_exists_partially_approved_reservation_2_approved_part_out_of_2_and_no_created_orders(
     ) {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let mut test_object = create_test_obj_with_multiple_currencies(
             vec![
                 BalanceManagerBase::eth(),
@@ -3931,7 +3931,7 @@ mod tests {
     #[test]
     pub fn clone_when_exists_partially_approved_reservation_1_approved_part_out_of_2_and_1_created_orders(
     ) {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let mut test_object = create_test_obj_with_multiple_currencies(
             vec![
                 BalanceManagerBase::eth(),
@@ -4055,7 +4055,7 @@ mod tests {
     #[test]
     pub fn clone_when_exists_partially_approved_reservation_2_approved_part_out_of_3_and_no_2_created_orders(
     ) {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let mut test_object = create_test_obj_with_multiple_currencies(
             vec![
                 BalanceManagerBase::eth(),
@@ -4193,7 +4193,7 @@ mod tests {
 
     #[test]
     pub fn unmatched_reserved_amount_and_order_amount_sum_sell() {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let test_object = create_test_obj_by_currency_code(BalanceManagerBase::eth(), dec!(1000));
 
         let reserve_parameters = test_object.balance_manager_base.create_reserve_parameters(
@@ -4235,7 +4235,7 @@ mod tests {
 
     #[test]
     pub fn unmatched_reserved_amount_and_order_amount_sum_buy() {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let test_object = create_test_obj_by_currency_code(BalanceManagerBase::btc(), dec!(1000));
 
         let reserve_parameters = test_object.balance_manager_base.create_reserve_parameters(
@@ -4277,7 +4277,7 @@ mod tests {
 
     #[test]
     pub fn can_reserve_reservation_limits_enough_and_not_enough() {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let test_object = create_test_obj_by_currency_code_with_limit(
             BalanceManagerBase::btc(),
             dec!(1),
@@ -4315,7 +4315,7 @@ mod tests {
 
     #[test]
     pub fn can_reserve_fill_and_reservation_limits_enough_and_not_enough() {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let limit = dec!(2);
         let start_amount = dec!(1);
         let mut test_object = create_test_obj_by_currency_code_with_limit(
@@ -4420,7 +4420,7 @@ mod tests {
 
     #[test]
     pub fn restore_state_ctor() {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let mut test_object = create_test_obj_by_currency_code(BalanceManagerBase::btc(), dec!(0));
         let (_, exchanges_by_id) = BalanceManagerOrdinal::create_balance_manager_ctor_parameters();
 
@@ -4504,7 +4504,7 @@ mod tests {
 
     #[test]
     pub fn update_exchange_balance_should_ignore_approved_reservations_for_canceled_orders() {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let mut test_object = create_test_obj_by_currency_code(BalanceManagerBase::btc(), dec!(10));
 
         let price = dec!(1);
@@ -4580,7 +4580,7 @@ mod tests {
 
     #[test]
     pub fn unreserve_should_reduce_not_approved_amount() {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let test_object = create_eth_btc_test_obj(dec!(10), dec!(0));
 
         let reserve_parameters = test_object.balance_manager_base.create_reserve_parameters(
@@ -4613,7 +4613,7 @@ mod tests {
 
     #[test]
     pub fn unreserve_should_reduce_not_approved_amount_approved_order_single_unreserve() {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let mut test_object = create_eth_btc_test_obj(dec!(10), dec!(0));
 
         let reserve_parameters = test_object.balance_manager_base.create_reserve_parameters(
@@ -4657,7 +4657,7 @@ mod tests {
 
     #[test]
     pub fn unreserve_should_reduce_not_approved_amount_approved_order_unreserve_twice_by_half() {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let mut test_object = create_eth_btc_test_obj(dec!(10), dec!(0));
 
         let reserve_parameters = test_object.balance_manager_base.create_reserve_parameters(
@@ -4715,7 +4715,7 @@ mod tests {
     #[should_panic(expected = "in test")]
     pub fn unreserve_should_reduce_not_approved_amount_approved_order_unreserve_more_than_we_have()
     {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let mut test_object = create_eth_btc_test_obj(dec!(10), dec!(0));
 
         let reserve_parameters = test_object.balance_manager_base.create_reserve_parameters(
@@ -4755,7 +4755,7 @@ mod tests {
 
     #[test]
     pub fn unreserve_should_reduce_not_approved_amount_not_approved_order_single_unreserve() {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let mut test_object = create_eth_btc_test_obj(dec!(10), dec!(0));
 
         let reserve_parameters = test_object.balance_manager_base.create_reserve_parameters(
@@ -4795,7 +4795,7 @@ mod tests {
     #[should_panic(expected = "in test")]
     pub fn unreserve_should_reduce_not_approved_amount_not_approved_order_unreserve_more_than_we_have(
     ) {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let mut test_object = create_eth_btc_test_obj(dec!(10), dec!(0));
 
         let reserve_parameters = test_object.balance_manager_base.create_reserve_parameters(
@@ -4832,7 +4832,7 @@ mod tests {
     #[test]
     #[ignore] // TODO: Should be fixed by https://github.com/CryptoDreamTeam/CryptoDreamTraderSharp/issues/802
     pub fn order_was_finished_should_unreserve_related_reservations() {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let mut test_object = create_test_obj_by_currency_code(BalanceManagerBase::btc(), dec!(10));
 
         let price = dec!(1);
@@ -4922,7 +4922,7 @@ mod tests {
     #[test]
     #[ignore] // TODO: Should be fixed by https://github.com/CryptoDreamTeam/CryptoDreamTraderSharp/issues/802
     pub fn order_was_filled_should_unreserve_related_reservations() {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let mut test_object = create_eth_btc_test_obj(dec!(10), dec!(0));
 
         let price = dec!(1);
@@ -5016,7 +5016,7 @@ mod tests {
     #[test]
     pub fn try_reserve_with_limit_for_borderline_case() {
         // preparing
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let mut test_object = create_eth_btc_test_obj(dec!(100), dec!(100));
 
         let exchange_account_id = test_object.balance_manager_base.exchange_account_id_1;
@@ -5132,7 +5132,7 @@ mod tests {
 
     #[test]
     pub fn get_last_position_change_before_period_base_cases() {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let mut test_object = create_eth_btc_test_obj(dec!(10), dec!(0));
 
         let exchange_account_id = test_object.balance_manager_base.exchange_account_id_1;

--- a/core/src/balance_manager/tests/virtual_balance_holder.rs
+++ b/core/src/balance_manager/tests/virtual_balance_holder.rs
@@ -88,7 +88,7 @@ impl VirtualBalanceHolderTests {
 mod tests {
     use std::collections::HashMap;
 
-    use mmb_utils::{hashmap, infrastructure::init_infrastructure};
+    use mmb_utils::{hashmap, logger::init_logger_file_named};
     use rust_decimal::Decimal;
     use rust_decimal_macros::dec;
 
@@ -118,7 +118,7 @@ mod tests {
 
     #[test]
     pub fn set_balance_simple() {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let mut test_obj = VirtualBalanceHolderTests::new();
 
         let exchange_account_id = test_obj.exchange_account_id;
@@ -136,7 +136,7 @@ mod tests {
 
     #[test]
     pub fn get_exchange_balance_multiple_currency_code() {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let mut test_obj = VirtualBalanceHolderTests::new();
 
         let exchange_account_id = test_obj.exchange_account_id;
@@ -156,7 +156,7 @@ mod tests {
 
     #[test]
     pub fn get_all_balances_valid() {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let mut test_obj = VirtualBalanceHolderTests::new();
 
         let exchange_account_id = test_obj.exchange_account_id;
@@ -190,7 +190,7 @@ mod tests {
     #[test]
     #[ignore] // Work in progress due to derivatives
     pub fn get_balance_for_derivative_with_mark_price() {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let mut test_obj =
             VirtualBalanceHolderTests::new_with_amount(VirtualBalanceHolderTests::btc().as_str());
 

--- a/core/src/lifecycle/shutdown.rs
+++ b/core/src/lifecycle/shutdown.rs
@@ -181,12 +181,12 @@ impl ShutdownService {
 mod tests {
     use super::*;
     use anyhow::Result;
-    use mmb_utils::infrastructure::init_infrastructure;
+    use mmb_utils::logger::init_logger_file_named;
     use tokio::sync::oneshot::Receiver;
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     pub async fn success() {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
 
         pub struct TestService;
 
@@ -220,7 +220,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     pub async fn failed() {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
 
         const REF_TEST_SERVICE: &str = "RefTestService";
         pub struct RefTestService(Mutex<Option<Arc<RefTestService>>>);

--- a/core/src/misc/service_value_tree.rs
+++ b/core/src/misc/service_value_tree.rs
@@ -250,8 +250,7 @@ mod test {
 
     use crate::exchanges::common::{CurrencyCode, CurrencyPair, ExchangeAccountId};
 
-    use mmb_utils::hashmap;
-    use mmb_utils::infrastructure::init_infrastructure;
+    use mmb_utils::{hashmap, logger::init_logger_file_named};
     use rust_decimal_macros::dec;
 
     use std::collections::HashMap;
@@ -333,14 +332,14 @@ mod test {
 
     #[test]
     pub fn get_as_balances() {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let test_data = get_test_data();
         assert_eq!(test_data.0.get_as_balances(), test_data.1);
     }
 
     #[test]
     pub fn set() {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let mut service_value_tree = ServiceValueTree::new();
 
         let service_name = "name".into();
@@ -468,7 +467,7 @@ mod test {
 
     #[test]
     pub fn add() {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let mut test_data = get_test_data();
 
         let new_service_name = "new_service_name".into();
@@ -507,7 +506,7 @@ mod test {
 
     #[test]
     pub fn compare() {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let mut service_value_tree = ServiceValueTree::new();
 
         let service_name = "name".into();
@@ -545,7 +544,7 @@ mod test {
     #[test]
     #[should_panic(expected = "assertion failed: `(left == right)`")]
     pub fn compare_failed_by_value() {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let mut service_value_tree = ServiceValueTree::new();
 
         let service_name = "name".into();
@@ -583,7 +582,7 @@ mod test {
     #[test]
     #[should_panic(expected = "assertion failed: `(left == right)`")]
     pub fn compare_failed_by_currency_code() {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let mut service_value_tree = ServiceValueTree::new();
 
         let service_name = "name".into();
@@ -621,7 +620,7 @@ mod test {
     #[test]
     #[should_panic(expected = "assertion failed: `(left == right)`")]
     pub fn compare_failed_by_currency_pair() {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let mut service_value_tree = ServiceValueTree::new();
 
         let service_name = "name".into();
@@ -659,7 +658,7 @@ mod test {
     #[test]
     #[should_panic(expected = "assertion failed: `(left == right)`")]
     pub fn compare_failed_by_exchange_account_id() {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let mut service_value_tree = ServiceValueTree::new();
 
         let service_name = "name".into();
@@ -697,7 +696,7 @@ mod test {
     #[test]
     #[should_panic(expected = "assertion failed: `(left == right)`")]
     pub fn compare_failed_by_service_configuration_key() {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let mut service_value_tree = ServiceValueTree::new();
 
         let service_name = "name".into();
@@ -735,7 +734,7 @@ mod test {
     #[test]
     #[should_panic(expected = "assertion failed: `(left == right)`")]
     pub fn compare_failed_by_service_name() {
-        init_infrastructure("log.txt");
+        init_logger_file_named("log.txt");
         let mut service_value_tree = ServiceValueTree::new();
 
         let service_name = "name".into();

--- a/exchanges/binance/tests/binance/account_balance.rs
+++ b/exchanges/binance/tests/binance/account_balance.rs
@@ -9,13 +9,13 @@ use mmb_core::exchanges::{
         },
     },
 };
-use mmb_utils::{cancellation_token::CancellationToken, infrastructure::init_infrastructure};
+use mmb_utils::{cancellation_token::CancellationToken, logger::init_logger_file_named};
 
 use super::binance_builder::BinanceBuilder;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn get_balance_successfully() {
-    init_infrastructure("log.txt");
+    init_logger_file_named("log.txt");
 
     let exchange_account_id: ExchangeAccountId = "Binance_0".parse().expect("in test");
     let binance_builder = match BinanceBuilder::try_new(

--- a/exchanges/binance/tests/binance/cancel_order.rs
+++ b/exchanges/binance/tests/binance/cancel_order.rs
@@ -5,14 +5,14 @@ use mmb_core::exchanges::general::exchange::*;
 use mmb_core::exchanges::general::features::*;
 use mmb_core::orders::order::*;
 use mmb_utils::cancellation_token::CancellationToken;
-use mmb_utils::infrastructure::init_infrastructure;
+use mmb_utils::logger::init_logger_file_named;
 
 use crate::binance::binance_builder::BinanceBuilder;
 use core_tests::order::OrderProxy;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn cancelled_successfully() {
-    init_infrastructure("log.txt");
+    init_logger_file_named("log.txt");
 
     let exchange_account_id: ExchangeAccountId = "Binance_0".parse().expect("in test");
     let binance_builder = match BinanceBuilder::try_new(
@@ -58,7 +58,7 @@ async fn cancelled_successfully() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn cancel_opened_orders_successfully() {
-    init_infrastructure("log.txt");
+    init_logger_file_named("log.txt");
 
     let exchange_account_id: ExchangeAccountId = "Binance_0".parse().expect("in test");
     let binance_builder = match BinanceBuilder::try_new(

--- a/exchanges/binance/tests/binance/create_order.rs
+++ b/exchanges/binance/tests/binance/create_order.rs
@@ -3,7 +3,7 @@ use mmb_core::exchanges::general::features::*;
 use mmb_core::exchanges::{events::AllowedEventSourceType, general::commission::Commission};
 use mmb_core::orders::event::OrderEventType;
 use mmb_utils::cancellation_token::CancellationToken;
-use mmb_utils::infrastructure::init_infrastructure;
+use mmb_utils::logger::init_logger_file_named;
 use rust_decimal_macros::*;
 
 use mmb_core::exchanges::events::ExchangeEvent;
@@ -13,7 +13,7 @@ use core_tests::order::OrderProxy;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn create_successfully() {
-    init_infrastructure("log.txt");
+    init_logger_file_named("log.txt");
 
     let exchange_account_id: ExchangeAccountId = "Binance_0".parse().expect("in test");
     let mut binance_builder = match BinanceBuilder::try_new(
@@ -76,7 +76,7 @@ async fn create_successfully() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn should_fail() {
-    init_infrastructure("log.txt");
+    init_logger_file_named("log.txt");
 
     let exchange_account_id: ExchangeAccountId = "Binance_0".parse().expect("in test");
     let binance_builder = match BinanceBuilder::try_new(

--- a/exchanges/binance/tests/binance/get_open_orders.rs
+++ b/exchanges/binance/tests/binance/get_open_orders.rs
@@ -4,7 +4,7 @@ use mmb_core::exchanges::general::commission::Commission;
 use mmb_core::exchanges::general::features::*;
 use mmb_core::settings::{CurrencyPairSetting, ExchangeSettings};
 use mmb_utils::cancellation_token::CancellationToken;
-use mmb_utils::infrastructure::init_infrastructure;
+use mmb_utils::logger::init_logger_file_named;
 
 use crate::binance::binance_builder::BinanceBuilder;
 use crate::get_binance_credentials_or_exit;
@@ -12,7 +12,7 @@ use core_tests::order::OrderProxy;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn open_orders_exists() {
-    init_infrastructure("log.txt");
+    init_logger_file_named("log.txt");
 
     let exchange_account_id: ExchangeAccountId = "Binance_0".parse().expect("in test");
     let binance_builder = match BinanceBuilder::try_new(
@@ -86,7 +86,7 @@ async fn open_orders_exists() {
 /// It's matter to check branch for OneCurrencyPair variant
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn get_open_orders_for_each_currency_pair_separately() {
-    init_infrastructure("log.txt");
+    init_logger_file_named("log.txt");
 
     let exchange_account_id: ExchangeAccountId = "Binance_0".parse().expect("in test");
     let (api_key, secret_key) = get_binance_credentials_or_exit!();

--- a/exchanges/binance/tests/binance/get_order_info.rs
+++ b/exchanges/binance/tests/binance/get_order_info.rs
@@ -6,14 +6,14 @@ use mmb_core::exchanges::general::commission::Commission;
 use mmb_core::exchanges::general::features::*;
 use mmb_core::orders::order::*;
 use mmb_utils::cancellation_token::CancellationToken;
-use mmb_utils::infrastructure::init_infrastructure;
+use mmb_utils::logger::init_logger_file_named;
 
 use crate::binance::binance_builder::BinanceBuilder;
 use core_tests::order::OrderProxy;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn get_order_info() {
-    init_infrastructure("log.txt");
+    init_logger_file_named("log.txt");
     let exchange_account_id: ExchangeAccountId = "Binance_0".parse().expect("in test");
     let binance_builder = match BinanceBuilder::try_new(
         exchange_account_id,

--- a/exchanges/binance/tests/binance/wait_cancel_order.rs
+++ b/exchanges/binance/tests/binance/wait_cancel_order.rs
@@ -5,14 +5,14 @@ use mmb_core::exchanges::general::commission::Commission;
 use mmb_core::exchanges::general::features::*;
 use mmb_core::settings::{CurrencyPairSetting, ExchangeSettings};
 use mmb_utils::cancellation_token::CancellationToken;
-use mmb_utils::infrastructure::init_infrastructure;
+use mmb_utils::logger::init_logger_file_named;
 
 use crate::binance::binance_builder::BinanceBuilder;
 use crate::get_binance_credentials_or_exit;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn cancellation_waited_successfully() {
-    init_infrastructure("log.txt");
+    init_logger_file_named("log.txt");
 
     let exchange_account_id: ExchangeAccountId = "Binance_0".parse().expect("in test");
     let (api_key, secret_key) = get_binance_credentials_or_exit!();
@@ -73,7 +73,7 @@ async fn cancellation_waited_successfully() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn cancellation_waited_failed_fallback() {
-    init_infrastructure("log.txt");
+    init_logger_file_named("log.txt");
 
     let exchange_account_id: ExchangeAccountId = "Binance_0".parse().expect("in test");
     let binance_builder = match BinanceBuilder::try_new(

--- a/exchanges/serum/tests/serum/account_balance.rs
+++ b/exchanges/serum/tests/serum/account_balance.rs
@@ -7,12 +7,12 @@ use mmb_core::exchanges::general::features::{
     WebSocketOptions,
 };
 use mmb_utils::cancellation_token::CancellationToken;
-use mmb_utils::infrastructure::init_infrastructure;
+use mmb_utils::logger::init_logger_file_named;
 
 #[ignore = "need solana keypair"]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn get_balance_successfully() {
-    init_infrastructure("log.txt");
+    init_logger_file_named("log.txt");
 
     let exchange_account_id = ExchangeAccountId::new("Serum".into(), 0);
     let serum_builder = SerumBuilder::try_new(

--- a/exchanges/serum/tests/serum/get_open_orders.rs
+++ b/exchanges/serum/tests/serum/get_open_orders.rs
@@ -10,14 +10,14 @@ use mmb_core::exchanges::general::features::{
 };
 use mmb_core::orders::order::{ClientOrderId, OrderSide};
 use mmb_utils::cancellation_token::CancellationToken;
-use mmb_utils::infrastructure::init_infrastructure;
+use mmb_utils::logger::init_logger_file_named;
 use rust_decimal_macros::dec;
 use std::collections::BTreeSet;
 
 #[ignore = "not yet implemented Serum::get_order_id()"]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn get_open_orders() -> Result<()> {
-    init_infrastructure("log.txt");
+    init_logger_file_named("log.txt");
 
     let exchange_account_id = ExchangeAccountId::new("Serum".into(), 0);
     let serum_builder = SerumBuilder::try_new(
@@ -90,7 +90,7 @@ async fn get_open_orders() -> Result<()> {
 #[ignore = "not yet implemented Serum::get_order_id()"]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn get_open_orders_for_currency_pair() -> Result<()> {
-    init_infrastructure("log.txt");
+    init_logger_file_named("log.txt");
 
     let exchange_account_id: ExchangeAccountId = "Serum_0".parse().expect("Parsing error");
     let serum_builder = SerumBuilder::try_new(

--- a/exchanges/serum/tests/serum/get_order_info.rs
+++ b/exchanges/serum/tests/serum/get_order_info.rs
@@ -10,13 +10,13 @@ use mmb_core::exchanges::general::features::{
 };
 use mmb_core::orders::order::OrderSide;
 use mmb_utils::cancellation_token::CancellationToken;
-use mmb_utils::infrastructure::init_infrastructure;
+use mmb_utils::logger::init_logger_file_named;
 use rust_decimal_macros::dec;
 
 #[ignore = "not yet implemented Serum::get_order_id()"]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn get_order_info() -> Result<()> {
-    init_infrastructure("log.txt");
+    init_logger_file_named("log.txt");
 
     let exchange_account_id: ExchangeAccountId = "Serum_0".parse().expect("Parsing error");
     let serum_builder = SerumBuilder::try_new(

--- a/mmb_utils/src/infrastructure.rs
+++ b/mmb_utils/src/infrastructure.rs
@@ -234,6 +234,7 @@ where
     }
 }
 
+/// Do not use this in tests because panics will not be logged #448
 pub fn init_infrastructure(log_file: &str) {
     set_panic_hook();
     init_logger_file_named(log_file);


### PR DESCRIPTION

Fixed panic logging by removing registering panic hook in tests.
Its not so critical now because in this way we only lost backtrace for panic in some cases in tests
Needed more investigation in the future