### PR TITLE
Fixed order creation in integration tests

### DIFF
--- a/core/src/exchanges/exchange_blocker.rs
+++ b/core/src/exchanges/exchange_blocker.rs
@@ -1042,13 +1042,16 @@ mod tests {
 
         let min_timeout = duration_sleep + duration;
         let timeout_limit = min_timeout + Duration::from_millis(30);
-        tokio::select! {
-            _ = handle => {
-                let elapsed = timer.elapsed();
-                assert!(elapsed > min_timeout, "Exchange should be unblocked after {} ms, but was {} ms", min_timeout.as_millis(), elapsed.as_millis())
-            },
-            _ = sleep(timeout_limit) => panic!("Timeout limit ({} ms) exceeded", timeout_limit.as_millis()),
-        }
+
+        let _ = with_timeout(timeout_limit, handle).await;
+
+        let elapsed = timer.elapsed();
+        assert!(
+            elapsed > min_timeout,
+            "Exchange should be unblocked after {} ms, but was {} ms",
+            min_timeout.as_millis(),
+            elapsed.as_millis()
+        )
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/core/src/exchanges/general/exchange_symbol.rs
+++ b/core/src/exchanges/general/exchange_symbol.rs
@@ -31,7 +31,7 @@ impl Exchange {
         });
 
         self.setup_symbols(get_symbols(
-            &currency_pairs,
+            currency_pairs,
             exchange_symbols,
             self.exchange_account_id,
         ));

--- a/core_tests/src/order.rs
+++ b/core_tests/src/order.rs
@@ -85,7 +85,7 @@ impl OrderProxy {
     }
 
     pub fn default_currency_pair() -> CurrencyPair {
-        CurrencyPair::from_codes("cnd".into(), "btc".into())
+        CurrencyPair::from_codes("btc".into(), "usdt".into())
     }
 
     pub fn make_header(&self) -> Arc<OrderHeader> {

--- a/example/src/config.toml
+++ b/example/src/config.toml
@@ -10,7 +10,8 @@ request_trades = false
 websocket_channels = ["depth20"]
 subscribe_to_market_data = true
 
-currency_pairs = [ { base = "cnd", quote = "btc"  },
-                   { base = "eth", quote = "btc"  },
-                   { base = "eos", quote = "btc"  },
-                   { base = "btc", quote = "usdt"  } ]
+currency_pairs = [
+    { base = "eth", quote = "btc"  },
+    { base = "eos", quote = "btc"  },
+    { base = "btc", quote = "usdt"  }
+]

--- a/exchanges/binance/config.toml
+++ b/exchanges/binance/config.toml
@@ -10,7 +10,8 @@ request_trades = false
 websocket_channels = ["depth20"]
 subscribe_to_market_data = true
 
-currency_pairs = [ { base = "cnd", quote = "btc"  },
-                   { base = "eth", quote = "btc"  },
-                   { base = "eos", quote = "btc"  },
-                   { base = "btc", quote = "usdt"  } ]
+currency_pairs = [
+    { base = "eth", quote = "btc"  },
+    { base = "eos", quote = "btc"  },
+    { base = "btc", quote = "usdt"  }
+]

--- a/exchanges/binance/tests/binance/binance_builder.rs
+++ b/exchanges/binance/tests/binance/binance_builder.rs
@@ -55,8 +55,8 @@ impl BinanceBuilder {
 
         // default currency pair for tests
         settings.currency_pairs = Some(vec![CurrencyPairSetting::Ordinary {
-            base: "cnd".into(),
-            quote: "btc".into(),
+            base: "btc".into(),
+            quote: "usdt".into(),
         }]);
 
         Self::try_new_with_settings(
@@ -123,11 +123,26 @@ impl BinanceBuilder {
                 .await;
         }
 
-        let currency_pair =
-            get_specific_currency_pair_for_tests(&exchange, OrderProxy::default_currency_pair());
-        let default_price = get_default_price(currency_pair, &hosts, &settings.api_key).await;
-        let min_amount =
-            get_min_amount(currency_pair, &hosts, &settings.api_key, default_price).await;
+        let currency_pair = OrderProxy::default_currency_pair();
+        let specific_currency_pair = get_specific_currency_pair_for_tests(&exchange, currency_pair);
+        let default_price =
+            get_default_price(specific_currency_pair, &hosts, &settings.api_key).await;
+
+        let symbol = exchange
+            .symbols
+            .get(&currency_pair)
+            .expect("can't find symbol")
+            .value()
+            .clone();
+
+        let min_amount = get_min_amount(
+            specific_currency_pair,
+            &hosts,
+            &settings.api_key,
+            default_price,
+            &symbol,
+        )
+        .await;
 
         Ok(Self {
             exchange,

--- a/exchanges/binance/tests/binance/get_open_orders.rs
+++ b/exchanges/binance/tests/binance/get_open_orders.rs
@@ -95,12 +95,12 @@ async fn get_open_orders_for_each_currency_pair_separately() {
 
     settings.currency_pairs = Some(vec![
         CurrencyPairSetting::Ordinary {
-            base: "cnd".into(),
-            quote: "btc".into(),
+            base: "btc".into(),
+            quote: "usdt".into(),
         },
         CurrencyPairSetting::Ordinary {
-            base: "cnd".into(),
-            quote: "btc".into(),
+            base: "btc".into(),
+            quote: "usdt".into(),
         },
     ]);
 

--- a/exchanges/binance/tests/binance/lifecycle.toml
+++ b/exchanges/binance/tests/binance/lifecycle.toml
@@ -7,6 +7,6 @@ request_trades = false
 websocket_channels = ["depth20"]
 subscribe_to_market_data = true
 
-currency_pairs = [ { base = "cnd", quote = "btc"  },
+currency_pairs = [ { base = "btc", quote = "usdt"  },
     { base = "eth", quote = "btc"  },
     { base = "eos", quote = "btc"  } ]

--- a/exchanges/binance/tests/binance/wait_cancel_order.rs
+++ b/exchanges/binance/tests/binance/wait_cancel_order.rs
@@ -22,8 +22,8 @@ async fn cancellation_waited_successfully() {
     // Currency pair in settings are matter here because of need to check
     // Symbol in check_order_fills() inside wait_cancel_order()
     settings.currency_pairs = Some(vec![CurrencyPairSetting::Ordinary {
-        base: "cnd".into(),
-        quote: "btc".into(),
+        base: "btc".into(),
+        quote: "usdt".into(),
     }]);
 
     let binance_builder = match BinanceBuilder::try_new_with_settings(

--- a/exchanges/binance/tests/control_panel/control_panel.toml
+++ b/exchanges/binance/tests/control_panel/control_panel.toml
@@ -7,4 +7,4 @@ request_trades = false
 websocket_channels = ["depth20"]
 subscribe_to_market_data = true
 
-currency_pairs = [ { base = "cnd", quote = "btc"  } ]
+currency_pairs = [ { base = "btc", quote = "usdt"  } ]

--- a/exchanges/binance/tests/control_panel/statistics.rs
+++ b/exchanges/binance/tests/control_panel/statistics.rs
@@ -48,7 +48,7 @@ impl BaseStrategySettings for TestStrategySettings {
     }
 
     fn currency_pair(&self) -> CurrencyPair {
-        CurrencyPair::from_codes("cnd".into(), "btc".into())
+        CurrencyPair::from_codes("btc".into(), "usdt".into())
     }
 
     fn max_amount(&self) -> Amount {
@@ -134,13 +134,23 @@ async fn orders_cancelled() {
             &api_key,
         )
         .await;
+
+        let symbol = exchange
+            .symbols
+            .get(&test_currency_pair)
+            .expect("can't find symbol")
+            .value()
+            .clone();
+
         let amount = get_min_amount(
             get_specific_currency_pair_for_tests(&exchange, test_currency_pair),
             &Binance::make_hosts(is_margin_trading),
             &api_key,
             price,
+            &symbol,
         )
         .await;
+
         let order = OrderProxy::new(
             exchange_account_id,
             Some("FromOrdersCancelledTest".to_owned()),
@@ -172,7 +182,7 @@ async fn orders_cancelled() {
     )
     .expect("failed to conver answer to Value");
 
-    let exchange_statistics = &statistics["market_account_id_stats"]["Binance_0|cnd/btc"];
+    let exchange_statistics = &statistics["market_account_id_stats"]["Binance_0|btc/usdt"];
     let opened_orders_count = exchange_statistics["opened_orders_count"]
         .as_u64()
         .expect("in test");


### PR DESCRIPTION

Changed used currency pair and method of price selection for orders in tests after delisting currency pair `cnd/btc` on Binance