### PR TITLE
Removed redundant logs in `spawn_future`

### DIFF
--- a/core/src/balance_changes/balance_changes_service.rs
+++ b/core/src/balance_changes/balance_changes_service.rs
@@ -125,7 +125,7 @@ impl BalanceChangesService {
             "BalanceChangesService",
             Duration::ZERO,
             Duration::from_secs(5),
-            SpawnFutureFlags::STOP_BY_TOKEN | SpawnFutureFlags::CRITICAL,
+            SpawnFutureFlags::STOP_BY_TOKEN | SpawnFutureFlags::DENY_CANCELLATION,
         );
 
         this

--- a/core/src/disposition_execution/executor.rs
+++ b/core/src/disposition_execution/executor.rs
@@ -91,7 +91,7 @@ impl DispositionExecutorService {
         };
         spawn_future(
             "Start disposition executor",
-            SpawnFutureFlags::STOP_BY_TOKEN | SpawnFutureFlags::CRITICAL,
+            SpawnFutureFlags::STOP_BY_TOKEN | SpawnFutureFlags::DENY_CANCELLATION,
             action.boxed(),
         );
 
@@ -568,7 +568,7 @@ impl DispositionExecutor {
         };
         spawn_future(
             "Start wait_cancel_order from DispositionExecutor::cancel_order()",
-            SpawnFutureFlags::STOP_BY_TOKEN | SpawnFutureFlags::CRITICAL,
+            SpawnFutureFlags::STOP_BY_TOKEN | SpawnFutureFlags::DENY_CANCELLATION,
             action.boxed(),
         );
     }
@@ -777,7 +777,7 @@ impl DispositionExecutor {
             };
             spawn_future(
                 "wait_cancel_order in blocking cancel_order",
-                SpawnFutureFlags::STOP_BY_TOKEN | SpawnFutureFlags::CRITICAL,
+                SpawnFutureFlags::STOP_BY_TOKEN | SpawnFutureFlags::DENY_CANCELLATION,
                 action.boxed(),
             );
         }

--- a/core/src/exchanges/exchange_blocker.rs
+++ b/core/src/exchanges/exchange_blocker.rs
@@ -234,7 +234,7 @@ impl ExchangeBlockerEventsProcessor {
         };
         let processing_handle = spawn_future(
             "Start ExchangeBlocker processing",
-            SpawnFutureFlags::STOP_BY_TOKEN | SpawnFutureFlags::CRITICAL,
+            SpawnFutureFlags::STOP_BY_TOKEN | SpawnFutureFlags::DENY_CANCELLATION,
             action.boxed(),
         );
 
@@ -343,7 +343,7 @@ impl ExchangeBlockerEventsProcessor {
                 };
                 let _ = spawn_future(
                     "Run ExchangeBlocker handlers in case MoveToBlocked",
-                    SpawnFutureFlags::STOP_BY_TOKEN | SpawnFutureFlags::CRITICAL,
+                    SpawnFutureFlags::STOP_BY_TOKEN | SpawnFutureFlags::DENY_CANCELLATION,
                     action.boxed(),
                 );
             }
@@ -368,7 +368,7 @@ impl ExchangeBlockerEventsProcessor {
                 };
                 let _ = spawn_future(
                     "Run ExchangeBlocker handlers in case WaitBeforeUnblockedMove",
-                    SpawnFutureFlags::STOP_BY_TOKEN | SpawnFutureFlags::CRITICAL,
+                    SpawnFutureFlags::STOP_BY_TOKEN | SpawnFutureFlags::DENY_CANCELLATION,
                     action.boxed(),
                 );
             }
@@ -389,7 +389,7 @@ impl ExchangeBlockerEventsProcessor {
 
                 let _ = spawn_future(
                     "Run ExchangeBlocker handlers in case WaitUnblockedMove",
-                    SpawnFutureFlags::STOP_BY_TOKEN | SpawnFutureFlags::CRITICAL,
+                    SpawnFutureFlags::STOP_BY_TOKEN | SpawnFutureFlags::DENY_CANCELLATION,
                     action.boxed(),
                 );
             }
@@ -671,7 +671,7 @@ impl ExchangeBlocker {
         };
         spawn_future(
             "Run ExchangeBlocker handlers",
-            SpawnFutureFlags::STOP_BY_TOKEN | SpawnFutureFlags::CRITICAL,
+            SpawnFutureFlags::STOP_BY_TOKEN | SpawnFutureFlags::DENY_CANCELLATION,
             action.boxed(),
         )
     }
@@ -1512,7 +1512,7 @@ mod tests {
         let (tx, mut rx) = tokio::sync::mpsc::channel(1);
         let _ = spawn_future(
             "Run wait_unblock in wait_unblock_when_reblock_1_of_2_reasons test",
-            SpawnFutureFlags::CRITICAL | SpawnFutureFlags::STOP_BY_TOKEN,
+            SpawnFutureFlags::DENY_CANCELLATION | SpawnFutureFlags::STOP_BY_TOKEN,
             {
                 let exchange_blocker = exchange_blocker.clone();
                 let wait_completed = wait_completed.clone();

--- a/core/src/exchanges/timeouts/more_or_equals_available_requests_count_trigger_scheduler.rs
+++ b/core/src/exchanges/timeouts/more_or_equals_available_requests_count_trigger_scheduler.rs
@@ -92,7 +92,7 @@ impl MoreOrEqualsAvailableRequestsCountTrigger {
         };
         spawn_future(
             "handle_inner for schedule_handler()",
-            SpawnFutureFlags::STOP_BY_TOKEN | SpawnFutureFlags::CRITICAL,
+            SpawnFutureFlags::STOP_BY_TOKEN | SpawnFutureFlags::DENY_CANCELLATION,
             action.boxed(),
         );
     }

--- a/core/src/exchanges/timeouts/requests_timeout_manager.rs
+++ b/core/src/exchanges/timeouts/requests_timeout_manager.rs
@@ -307,7 +307,7 @@ impl RequestsTimeoutManager {
         );
         let request_availability = spawn_future(
             "Waiting request in reserve_when_available()",
-            SpawnFutureFlags::STOP_BY_TOKEN | SpawnFutureFlags::CRITICAL,
+            SpawnFutureFlags::STOP_BY_TOKEN | SpawnFutureFlags::DENY_CANCELLATION,
             action.boxed(),
         );
 

--- a/core/src/lifecycle/launcher.rs
+++ b/core/src/lifecycle/launcher.rs
@@ -250,7 +250,7 @@ where
         );
         let _ = spawn_future(
             "internal_events_loop start",
-            SpawnFutureFlags::STOP_BY_TOKEN | SpawnFutureFlags::CRITICAL,
+            SpawnFutureFlags::STOP_BY_TOKEN | SpawnFutureFlags::DENY_CANCELLATION,
             action.boxed(),
         );
     }
@@ -329,7 +329,7 @@ where
 
     let _ = spawn_future(
         "Start Ctrl-C handler",
-        SpawnFutureFlags::STOP_BY_TOKEN | SpawnFutureFlags::CRITICAL,
+        SpawnFutureFlags::STOP_BY_TOKEN | SpawnFutureFlags::DENY_CANCELLATION,
         action.boxed(),
     );
 

--- a/core/src/misc/position_helper.rs
+++ b/core/src/misc/position_helper.rs
@@ -52,7 +52,7 @@ pub fn close_position_if_needed(
     let action_name = "Close active positions";
     Some(spawn_future_timed(
         action_name,
-        SpawnFutureFlags::STOP_BY_TOKEN | SpawnFutureFlags::CRITICAL,
+        SpawnFutureFlags::STOP_BY_TOKEN | SpawnFutureFlags::DENY_CANCELLATION,
         Duration::from_secs(30),
         action.boxed(),
     ))

--- a/core/src/rpc/common.rs
+++ b/core/src/rpc/common.rs
@@ -142,7 +142,7 @@ pub(super) fn spawn_server_stopping_action<T>(
 
     spawn_future(
         future_name,
-        SpawnFutureFlags::CRITICAL,
+        SpawnFutureFlags::DENY_CANCELLATION,
         stopping_action.boxed(),
     );
 }

--- a/core/src/services/usd_converter/price_source_service.rs
+++ b/core/src/services/usd_converter/price_source_service.rs
@@ -66,7 +66,7 @@ impl PriceSourceEventLoop {
         };
         spawn_future(
             "PriceSourceService",
-            SpawnFutureFlags::STOP_BY_TOKEN | SpawnFutureFlags::CRITICAL,
+            SpawnFutureFlags::STOP_BY_TOKEN | SpawnFutureFlags::DENY_CANCELLATION,
             run_action.boxed(),
         )
         .await

--- a/core/src/services/usd_converter/usd_denominator.rs
+++ b/core/src/services/usd_converter/usd_denominator.rs
@@ -63,7 +63,7 @@ impl UsdDenominator {
                 "UsdDenominator::refresh_data()",
                 Duration::ZERO,
                 Duration::from_secs(7200), // 2 hours
-                SpawnFutureFlags::STOP_BY_TOKEN | SpawnFutureFlags::CRITICAL,
+                SpawnFutureFlags::STOP_BY_TOKEN | SpawnFutureFlags::DENY_CANCELLATION,
             );
         }
 

--- a/core/src/statistic_service.rs
+++ b/core/src/statistic_service.rs
@@ -241,7 +241,7 @@ impl StatisticEventHandler {
         let action = statistic_event_handler.clone().start(events_receiver);
         spawn_future(
             "Start statistic service",
-            SpawnFutureFlags::STOP_BY_TOKEN | SpawnFutureFlags::CRITICAL,
+            SpawnFutureFlags::STOP_BY_TOKEN | SpawnFutureFlags::DENY_CANCELLATION,
             action.boxed(),
         );
 

--- a/exchanges/binance/tests/binance/lifecycle.rs
+++ b/exchanges/binance/tests/binance/lifecycle.rs
@@ -100,7 +100,7 @@ async fn launch_engine() -> Result<()> {
     };
     spawn_future(
         "run graceful_shutdown in launch_engine test",
-        SpawnFutureFlags::CRITICAL,
+        SpawnFutureFlags::DENY_CANCELLATION,
         action.boxed(),
     );
 

--- a/exchanges/binance/tests/control_panel/statistics.rs
+++ b/exchanges/binance/tests/control_panel/statistics.rs
@@ -207,7 +207,7 @@ async fn orders_cancelled() {
     };
     spawn_future(
         "run graceful_shutdown in launch_engine test",
-        SpawnFutureFlags::CRITICAL | SpawnFutureFlags::STOP_BY_TOKEN,
+        SpawnFutureFlags::DENY_CANCELLATION | SpawnFutureFlags::STOP_BY_TOKEN,
         action.boxed(),
     );
 


### PR DESCRIPTION

- Removed redundant logs in `spawn_future`
- Renamed flag `SpawnFutureFlags::CRITICAL` to `SpawnFutureFlags::DENY_CANCELLATION`