### PR TITLE
Fixed parsing OrderId for Binance exchange

### DIFF
--- a/exchanges/binance/src/binance.rs
+++ b/exchanges/binance/src/binance.rs
@@ -1167,5 +1167,5 @@ mod tests {
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct OrderId {
-    order_id: u32,
+    order_id: u64,
 }


### PR DESCRIPTION

Sometimes `u32` value range is not enough for deserialization of order id. Changed to `u64`.