### PR TITLE
Fixed close all orders for serum

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1222,6 +1222,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4bb454f0228b18c7f4c3b0ebbee346ed9c52e7443b0999cd543ff3571205701d"
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21e50f3adc76d6a43f5ed73b698a87d0760ca74617f60f7c3b879003536fdd28"
+
+[[package]]
 name = "ed25519"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1360,6 +1366,15 @@ dependencies = [
  "log",
  "regex",
  "termcolor",
+]
+
+[[package]]
+name = "erased-serde"
+version = "0.3.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad132dd8d0d0b546348d7d86cb3191aad14b34e5f979781fc005c80d4ac67ffd"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -1686,6 +1701,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ghost"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a5bcf1bbeab73aa4cf2fde60a846858dc036163c7c33bec309f8d17de785479"
+dependencies = [
+ "proc-macro2 1.0.34",
+ "quote 1.0.10",
+ "syn 1.0.83",
+]
+
+[[package]]
 name = "gimli"
 version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1949,6 +1975,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "inventory"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6b5d8c669bfbad811d95ddd7a1c6cf9cfdbf2777e59928b6f3fa8ff54f72a0"
+dependencies = [
+ "ctor",
+ "ghost",
 ]
 
 [[package]]
@@ -2357,6 +2393,7 @@ dependencies = [
  "chrono",
  "crypto-mac 0.11.1",
  "dashmap 4.0.2",
+ "dyn-clone",
  "enum-map",
  "form_urlencoded",
  "futures 0.3.19",
@@ -2392,6 +2429,7 @@ dependencies = [
  "tokio",
  "tokio-tungstenite 0.16.1",
  "toml_edit",
+ "typetag",
  "url 2.2.2",
  "uuid",
 ]
@@ -3575,6 +3613,7 @@ dependencies = [
  "solana-sdk",
  "spl-token",
  "tokio",
+ "typetag",
  "url 2.2.2",
 ]
 
@@ -4905,6 +4944,30 @@ name = "typenum"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b63708a265f51345575b27fe43f9500ad611579e764c79edbc2037b1121959ec"
+
+[[package]]
+name = "typetag"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4080564c5b2241b5bff53ab610082234e0c57b0417f4bd10596f183001505b8a"
+dependencies = [
+ "erased-serde",
+ "inventory",
+ "once_cell",
+ "serde",
+ "typetag-impl",
+]
+
+[[package]]
+name = "typetag-impl"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e60147782cc30833c05fba3bab1d9b5771b2685a2557672ac96fa5d154099c0e"
+dependencies = [
+ "proc-macro2 1.0.34",
+ "quote 1.0.10",
+ "syn 1.0.83",
+]
 
 [[package]]
 name = "ucd-trie"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -17,6 +17,8 @@ crypto-mac = { version = "0.11", features = ["std"]}
 
 dashmap = "4"
 
+dyn-clone = "1"
+
 enum-map = "1.1.1"
 
 form_urlencoded = "1"
@@ -57,6 +59,7 @@ thiserror = "1"
 tokio = { version = "1", features = ["macros", "time", "sync", "rt-multi-thread", "signal"]}
 tokio-tungstenite = { version = "0.16", features = ["native-tls"] }
 toml_edit = { version = "0.12", features = ["serde"] }
+typetag = "0.1.8"
 
 url = "2.0"
 uuid = { version = "0.8", features = ["serde", "v4"]}

--- a/core/src/balance_manager/tests/balance_manager_base.rs
+++ b/core/src/balance_manager/tests/balance_manager_base.rs
@@ -263,6 +263,7 @@ impl BalanceManagerBase {
             fills: Default::default(),
             status_history: Default::default(),
             internal_props: Default::default(),
+            extension_data: None,
         };
         self.order_index += 1;
         order_snapshot

--- a/core/src/exchanges/general/exchange.rs
+++ b/core/src/exchanges/general/exchange.rs
@@ -138,6 +138,7 @@ impl Exchange {
     pub fn new(
         exchange_account_id: ExchangeAccountId,
         exchange_client: BoxExchangeClient,
+        orders: Arc<OrdersPool>,
         features: ExchangeFeatures,
         timeout_arguments: RequestTimeoutArguments,
         events_channel: broadcast::Sender<ExchangeEvent>,
@@ -151,7 +152,7 @@ impl Exchange {
         let exchange = Arc::new(Self {
             exchange_account_id,
             exchange_client,
-            orders: OrdersPool::new(),
+            orders,
             connectivity_manager,
             order_creation_events: DashMap::new(),
             order_cancellation_events: DashMap::new(),

--- a/core/src/exchanges/general/exchange_creation.rs
+++ b/core/src/exchanges/general/exchange_creation.rs
@@ -4,6 +4,7 @@ use super::commission::Commission;
 use crate::exchanges::events::ExchangeEvent;
 use crate::lifecycle::app_lifetime_manager::AppLifetimeManager;
 use crate::lifecycle::launcher::EngineBuildConfig;
+use crate::orders::pool::OrdersPool;
 use crate::settings::ExchangeSettings;
 use crate::{
     exchanges::{
@@ -49,16 +50,19 @@ pub async fn create_exchange(
 ) -> Arc<Exchange> {
     let exchange_client_builder =
         &build_settings.supported_exchange_clients[&user_settings.exchange_account_id.exchange_id];
+    let orders = OrdersPool::new();
 
     let exchange_client = exchange_client_builder.create_exchange_client(
         user_settings.clone(),
         events_channel.clone(),
         lifetime_manager.clone(),
+        orders.clone(),
     );
 
     let exchange = Exchange::new(
         user_settings.exchange_account_id,
         exchange_client.client,
+        orders,
         exchange_client.features,
         exchange_client_builder.get_timeout_arguments(),
         events_channel,

--- a/core/src/exchanges/general/handlers/handle_cancel_order_failed.rs
+++ b/core/src/exchanges/general/handlers/handle_cancel_order_failed.rs
@@ -203,6 +203,7 @@ mod test {
                 OrderFills::default(),
                 OrderStatusHistory::default(),
                 SystemInternalOrderProps::default(),
+                None,
             );
             let order_pool = OrdersPool::new();
             let order_ref = order_pool.add_snapshot_initial(Arc::new(RwLock::new(order)));
@@ -264,6 +265,7 @@ mod test {
                 OrderFills::default(),
                 OrderStatusHistory::default(),
                 SystemInternalOrderProps::default(),
+                None,
             );
             let order_pool = OrdersPool::new();
             let order_ref = order_pool.add_snapshot_initial(Arc::new(RwLock::new(order)));
@@ -329,6 +331,7 @@ mod test {
                 OrderFills::default(),
                 OrderStatusHistory::default(),
                 SystemInternalOrderProps::default(),
+                None,
             );
             let order_pool = OrdersPool::new();
             order.internal_props.is_canceling_from_wait_cancel_order = true;
@@ -409,6 +412,7 @@ mod test {
                 OrderFills::default(),
                 OrderStatusHistory::default(),
                 SystemInternalOrderProps::default(),
+                None,
             );
             order.internal_props.is_canceling_from_wait_cancel_order = false;
             let order_pool = OrdersPool::new();
@@ -496,6 +500,7 @@ mod test {
             OrderFills::default(),
             OrderStatusHistory::default(),
             SystemInternalOrderProps::default(),
+            None,
         );
         let order_pool = OrdersPool::new();
         let order_ref = order_pool.add_snapshot_initial(Arc::new(RwLock::new(order)));
@@ -575,6 +580,7 @@ mod test {
             OrderFills::default(),
             OrderStatusHistory::default(),
             SystemInternalOrderProps::default(),
+            None,
         );
         let order_pool = OrdersPool::new();
         let order_ref = order_pool.add_snapshot_initial(Arc::new(RwLock::new(order)));

--- a/core/src/exchanges/general/handlers/handle_order_filled.rs
+++ b/core/src/exchanges/general/handlers/handle_order_filled.rs
@@ -1478,6 +1478,7 @@ mod test {
             OrderFills::default(),
             OrderStatusHistory::default(),
             SystemInternalOrderProps::default(),
+            None,
         );
 
         let order_pool = OrdersPool::new();
@@ -1590,6 +1591,7 @@ mod test {
             OrderFills::default(),
             OrderStatusHistory::default(),
             SystemInternalOrderProps::default(),
+            None,
         );
 
         let order_pool = OrdersPool::new();
@@ -1702,6 +1704,7 @@ mod test {
             OrderFills::default(),
             OrderStatusHistory::default(),
             SystemInternalOrderProps::default(),
+            None,
         );
 
         let order_pool = OrdersPool::new();
@@ -1819,6 +1822,7 @@ mod test {
             OrderFills::default(),
             OrderStatusHistory::default(),
             SystemInternalOrderProps::default(),
+            None,
         );
 
         let order_pool = OrdersPool::new();
@@ -1934,6 +1938,7 @@ mod test {
             OrderFills::default(),
             OrderStatusHistory::default(),
             SystemInternalOrderProps::default(),
+            None,
         );
 
         let order_pool = OrdersPool::new();

--- a/core/src/exchanges/general/order/create_websocket_based.rs
+++ b/core/src/exchanges/general/order/create_websocket_based.rs
@@ -1,12 +1,10 @@
 use mmb_utils::cancellation_token::CancellationToken;
 use tokio::sync::oneshot;
 
+use crate::orders::pool::OrderRef;
 use crate::{
-    exchanges::general::exchange::Exchange,
-    exchanges::general::exchange::RequestResult,
-    orders::order::ClientOrderId,
-    orders::order::ExchangeOrderId,
-    orders::{fill::EventSourceType, order::OrderCreating},
+    exchanges::general::exchange::Exchange, exchanges::general::exchange::RequestResult,
+    orders::fill::EventSourceType, orders::order::ClientOrderId, orders::order::ExchangeOrderId,
 };
 
 use super::create::CreateOrderResult;
@@ -14,10 +12,10 @@ use super::create::CreateOrderResult;
 impl Exchange {
     pub(super) async fn create_order_core(
         &self,
-        order: OrderCreating,
+        order: &OrderRef,
         cancellation_token: CancellationToken,
     ) -> Option<CreateOrderResult> {
-        let client_order_id = order.header.client_order_id.clone();
+        let client_order_id = order.client_order_id();
         let (tx, mut websocket_event_receiver) = oneshot::channel();
 
         // TODO insert is not analog of C# GetOrAd!

--- a/core/src/exchanges/general/order/get_open_orders.rs
+++ b/core/src/exchanges/general/order/get_open_orders.rs
@@ -151,6 +151,7 @@ impl Exchange {
                 fills: Default::default(),
                 status_history: Default::default(),
                 internal_props: Default::default(),
+                extension_data: order.extension_data.clone(),
             }));
 
             let new_order = self.orders.add_snapshot_initial(new_snapshot);

--- a/core/src/exchanges/general/test_helper.rs
+++ b/core/src/exchanges/general/test_helper.rs
@@ -28,8 +28,8 @@ use crate::{
     orders::{
         fill::EventSourceType,
         order::{
-            ClientOrderId, ExchangeOrderId, OrderCancelling, OrderCreating, OrderInfo, OrderRole,
-            OrderSide, OrderSnapshot, OrderType,
+            ClientOrderId, ExchangeOrderId, OrderCancelling, OrderInfo, OrderRole, OrderSide,
+            OrderSnapshot, OrderType,
         },
         pool::{OrderRef, OrdersPool},
     },
@@ -58,7 +58,7 @@ pub struct TestClient;
 
 #[async_trait]
 impl ExchangeClient for TestClient {
-    async fn create_order(&self, _order: OrderCreating) -> CreateOrderResult {
+    async fn create_order(&self, _order: &OrderRef) -> CreateOrderResult {
         unimplemented!("doesn't need in UT")
     }
 
@@ -266,6 +266,7 @@ pub(crate) fn get_test_exchange_with_symbol_and_id(
     let exchange = Exchange::new(
         exchange_account_id,
         exchange_client,
+        OrdersPool::new(),
         ExchangeFeatures::new(
             OpenOrdersType::AllCurrencyPair,
             RestFillsFeatures::default(),

--- a/core/src/exchanges/traits.rs
+++ b/core/src/exchanges/traits.rs
@@ -26,9 +26,8 @@ use crate::exchanges::general::order::cancel::CancelOrderResult;
 use crate::exchanges::general::order::create::CreateOrderResult;
 use crate::lifecycle::app_lifetime_manager::AppLifetimeManager;
 use crate::orders::fill::EventSourceType;
-use crate::orders::order::{
-    ClientOrderId, ExchangeOrderId, OrderCancelling, OrderCreating, OrderInfo,
-};
+use crate::orders::order::{ClientOrderId, ExchangeOrderId, OrderCancelling, OrderInfo};
+use crate::orders::pool::OrdersPool;
 use crate::settings::ExchangeSettings;
 use crate::{connectivity::connectivity_manager::WebSocketRole, orders::order::OrderSide};
 use crate::{exchanges::general::exchange::BoxExchangeClient, orders::pool::OrderRef};
@@ -37,7 +36,7 @@ use url::Url;
 // Implementation of rest API client
 #[async_trait]
 pub trait ExchangeClient: Support {
-    async fn create_order(&self, order: OrderCreating) -> CreateOrderResult;
+    async fn create_order(&self, order: &OrderRef) -> CreateOrderResult;
 
     async fn cancel_order(&self, order: OrderCancelling) -> CancelOrderResult;
 
@@ -136,6 +135,7 @@ pub trait ExchangeClientBuilder {
         exchange_settings: ExchangeSettings,
         events_channel: broadcast::Sender<ExchangeEvent>,
         lifetime_manager: Arc<AppLifetimeManager>,
+        orders: Arc<OrdersPool>,
     ) -> ExchangeClientBuilderResult;
 
     fn get_timeout_arguments(&self) -> RequestTimeoutArguments;

--- a/core/src/misc/service_value_tree.rs
+++ b/core/src/misc/service_value_tree.rs
@@ -19,7 +19,7 @@ pub(crate) type CurrencyPairByCurrencyPair = HashMap<CurrencyPair, ValueByCurren
 pub(crate) type ValueByCurrencyCode = HashMap<CurrencyCode, Amount>;
 
 /// A tree that contain balance amounts distributed by
-/// ServiceNames -> ConfigurationKeys -> ExchangerAccountIds -> CurrencyPairs -> CurrencyCodes.
+/// ServiceNames -> ConfigurationKeys -> ExchangeAccountIds -> CurrencyPairs -> CurrencyCodes.
 ///     NOTE: there is storing all balances by ServiceNames(strategy name),
 ///     that will contain several configuration keys for strategies, next layer is one or more accounts for
 ///     selected ServiceName and here stored CurrencyCodes by CurrencyPairs and amount for every currency code.

--- a/core/src/orders/pool.rs
+++ b/core/src/orders/pool.rs
@@ -98,6 +98,7 @@ impl OrderRef {
                 .map(|exchange_order_id| OrderCancelling {
                     header: order.header.clone(),
                     exchange_order_id: exchange_order_id.clone(),
+                    extension_data: order.extension_data.clone(),
                 })
         })
     }
@@ -149,6 +150,7 @@ impl OrdersPool {
                     fills: Default::default(),
                     status_history: Default::default(),
                     internal_props: Default::default(),
+                    extension_data: None,
                 }));
 
                 self.add_snapshot_initial(snapshot)

--- a/core_tests/src/order.rs
+++ b/core_tests/src/order.rs
@@ -124,7 +124,10 @@ impl OrderProxy {
         let order_to_cancel = OrderCancelling {
             header: header.clone(),
             exchange_order_id,
+            extension_data: order_ref.fn_ref(|s| s.extension_data.clone()),
         };
+
+        order_ref.fn_mut(|order| order.set_status(OrderStatus::Canceling, Utc::now()));
 
         let cancel_outcome = exchange
             .cancel_order(order_to_cancel, CancellationToken::default())

--- a/exchanges/binance/src/exchange_client.rs
+++ b/exchanges/binance/src/exchange_client.rs
@@ -23,7 +23,7 @@ use std::sync::Arc;
 
 #[async_trait]
 impl ExchangeClient for Binance {
-    async fn create_order(&self, order: OrderCreating) -> CreateOrderResult {
+    async fn create_order(&self, order: &OrderRef) -> CreateOrderResult {
         match self.request_create_order(order).await {
             Ok(request_outcome) => match self.get_order_id(&request_outcome) {
                 Ok(created_order_id) => {

--- a/exchanges/binance/tests/binance/binance_builder.rs
+++ b/exchanges/binance/tests/binance/binance_builder.rs
@@ -11,6 +11,7 @@ use mmb_core::exchanges::general::features::*;
 use mmb_core::exchanges::hosts::Hosts;
 use mmb_core::exchanges::timeouts::requests_timeout_manager_factory::RequestTimeoutArguments;
 use mmb_core::infrastructure::init_lifetime_manager;
+use mmb_core::orders::pool::OrdersPool;
 use mmb_core::settings::CurrencyPairSetting;
 use mmb_core::settings::ExchangeSettings;
 use mmb_utils::cancellation_token::CancellationToken;
@@ -98,6 +99,7 @@ impl BinanceBuilder {
         let exchange = Exchange::new(
             exchange_account_id,
             binance,
+            OrdersPool::new(),
             features,
             RequestTimeoutArguments::from_requests_per_minute(1200),
             tx.clone(),

--- a/exchanges/binance/tests/binance/cancel_order.rs
+++ b/exchanges/binance/tests/binance/cancel_order.rs
@@ -168,6 +168,7 @@ async fn nothing_to_cancel() {
     let order_to_cancel = OrderCancelling {
         header: order.make_header(),
         exchange_order_id: "1234567890".into(),
+        extension_data: None,
     };
 
     // Cancel last order

--- a/exchanges/serum/Cargo.toml
+++ b/exchanges/serum/Cargo.toml
@@ -33,6 +33,7 @@ solana-program = "1.10"
 solana-sdk = "1.10"
 spl-token = { version = "3.2", features = ["no-entrypoint"], default-features = false }
 tokio = { version = "1" }
+typetag = "0.1.8"
 url = "2.0"
 function_name = "0.2.0"
 

--- a/exchanges/serum/src/exchange_client.rs
+++ b/exchanges/serum/src/exchange_client.rs
@@ -23,13 +23,13 @@ use mmb_core::exchanges::general::order::get_order_trades::OrderTrade;
 use mmb_core::exchanges::general::symbol::Symbol;
 use mmb_core::exchanges::traits::ExchangeClient;
 use mmb_core::orders::fill::EventSourceType;
-use mmb_core::orders::order::{OrderCancelling, OrderCreating, OrderInfo};
+use mmb_core::orders::order::{OrderCancelling, OrderInfo};
 use mmb_core::orders::pool::OrderRef;
 use mmb_utils::DateTime;
 
 #[async_trait]
 impl ExchangeClient for Serum {
-    async fn create_order(&self, order: OrderCreating) -> CreateOrderResult {
+    async fn create_order(&self, order: &OrderRef) -> CreateOrderResult {
         // TODO Possible handle ExchangeError in create_order_core
         match self.create_order_core(order).await {
             Ok(exchange_order_id) => {

--- a/exchanges/serum/src/market.rs
+++ b/exchanges/serum/src/market.rs
@@ -1,6 +1,4 @@
 use anyhow::Result;
-use mmb_core::exchanges::common::CurrencyPair;
-use mmb_core::orders::order::{ExchangeOrderId, OrderStatus};
 use mmb_utils::infrastructure::WithExpect;
 use rust_decimal::prelude::ToPrimitive;
 use rust_decimal::{Decimal, MathematicalOps};
@@ -9,13 +7,6 @@ use serde::Deserialize;
 use serum_dex::matching::Side;
 use serum_dex::state::MarketState;
 use solana_program::pubkey::Pubkey;
-
-pub struct OrderSerumInfo {
-    pub currency_pair: CurrencyPair,
-    pub owner: Pubkey,
-    pub status: OrderStatus,
-    pub exchange_order_id: ExchangeOrderId,
-}
 
 #[repr(C, packed)]
 #[derive(Debug, Copy, Clone)]

--- a/exchanges/serum/src/solana_client.rs
+++ b/exchanges/serum/src/solana_client.rs
@@ -320,7 +320,7 @@ impl SolanaClient {
         .to_string();
 
         let send_websocket_message_future =
-            (&self.send_websocket_message_callback.lock())(WebSocketRole::Main, message);
+            self.send_websocket_message_callback.lock()(WebSocketRole::Main, message);
         send_websocket_message_future.await
     }
 }

--- a/exchanges/serum/tests/serum/create_order.rs
+++ b/exchanges/serum/tests/serum/create_order.rs
@@ -7,11 +7,14 @@ use mmb_core::exchanges::general::features::{
     ExchangeFeatures, OpenOrdersType, OrderFeatures, OrderTradeOption, RestFillsFeatures,
     WebSocketOptions,
 };
-use mmb_core::orders::event::OrderEventType;
+use mmb_core::orders::event::{OrderEvent, OrderEventType};
 use mmb_core::orders::order::OrderSide;
 use mmb_utils::cancellation_token::CancellationToken;
+use mmb_utils::nothing_to_do;
 use rust_decimal_macros::dec;
 use std::time::Duration;
+use tokio::sync::broadcast;
+use tokio::time::sleep;
 
 #[ignore = "need solana keypair"]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -53,24 +56,39 @@ async fn create_successfully() {
         .await
         .expect("Create order failed with error");
 
-    let event = serum_builder
-        .rx
-        .recv()
-        .await
-        .expect("CreateOrderSucceeded event had to be occurred");
-
-    let order_event = if let ExchangeEvent::OrderEvent(order_event) = event {
-        order_event
-    } else {
-        panic!("Should receive OrderEvent {:?}", event)
-    };
-
-    match order_event.event_type {
-        OrderEventType::CreateOrderSucceeded => {}
-        _ => panic!("Should receive CreateOrderSucceeded event type"),
-    }
+    check_exchange_order_event_is_succeed_or_panic(&mut serum_builder.rx).await;
 
     order_proxy
         .cancel_order_or_fail(&order_ref, serum_builder.exchange.clone())
         .await;
+}
+
+async fn receive_exchange_order_event(
+    receiver: &mut broadcast::Receiver<ExchangeEvent>,
+) -> OrderEvent {
+    // we can get another event first
+    for attempt in 0..3 {
+        let event = receiver.recv().await.expect("Failed to get exchange event");
+        if let ExchangeEvent::OrderEvent(order_event) = event {
+            return order_event;
+        }
+
+        log::warn!("Should receive OrderEvent {:?}. Attempt {}", event, attempt);
+    }
+
+    panic!("Should receive OrderEvent")
+}
+
+async fn check_exchange_order_event_is_succeed_or_panic(
+    receiver: &mut broadcast::Receiver<ExchangeEvent>,
+) {
+    tokio::select! {
+        order_event = receive_exchange_order_event(receiver) => {
+            match order_event.event_type {
+                OrderEventType::CreateOrderSucceeded => nothing_to_do(),
+                _ => panic!("Should receive CreateOrderSucceeded event type"),
+            }
+        },
+        _ = sleep(Duration::from_secs(2)) => panic!("Receiver exchange order event time is gone")
+    }
 }

--- a/exchanges/serum/tests/serum/serum_builder.rs
+++ b/exchanges/serum/tests/serum/serum_builder.rs
@@ -12,6 +12,7 @@ use mmb_core::exchanges::general::exchange::Exchange;
 use mmb_core::exchanges::general::features::ExchangeFeatures;
 use mmb_core::exchanges::timeouts::requests_timeout_manager_factory::RequestTimeoutArguments;
 use mmb_core::infrastructure::init_lifetime_manager;
+use mmb_core::orders::pool::OrdersPool;
 use mmb_core::settings::{CurrencyPairSetting, ExchangeSettings};
 use mmb_utils::cancellation_token::CancellationToken;
 
@@ -51,12 +52,14 @@ impl SerumBuilder {
         let (tx, rx) = broadcast::channel(10);
         let timeout_manager = get_timeout_manager(exchange_account_id);
         let network_type = get_network_type().context("Get network type")?;
+        let orders_pool = OrdersPool::new();
 
         let serum = Box::new(Serum::new(
             exchange_account_id,
             settings.clone(),
             tx.clone(),
             lifetime_manager.clone(),
+            orders_pool.clone(),
             network_type,
             false,
         ));
@@ -64,6 +67,7 @@ impl SerumBuilder {
         let exchange = Exchange::new(
             exchange_account_id,
             serum,
+            orders_pool,
             features,
             RequestTimeoutArguments::from_requests_per_minute(240),
             tx.clone(),


### PR DESCRIPTION

- Moved internal owner id to extension data in `OrderSnapshot` and `OrderInfo`
- Fixed possible creation and canceling events duplication