### PR TITLE
Optimized `BalanceManager::clone_and_subtract_not_approved_data()`

### DIFF
--- a/core/src/balance/manager/tests/balance_manager_derivative.rs
+++ b/core/src/balance/manager/tests/balance_manager_derivative.rs
@@ -1895,7 +1895,7 @@ mod tests {
                 .as_ref()
                 .expect("in test")
                 .clone(),
-            Some(vec![order_ref]),
+            Some(&mut vec![order_ref].iter()),
         )
         .expect("in test");
 
@@ -1976,7 +1976,7 @@ mod tests {
                 .as_ref()
                 .expect("in test")
                 .clone(),
-            Some(vec![order_ref]),
+            Some(&mut vec![order_ref].iter()),
         )
         .expect("in test");
 

--- a/core/src/balance/manager/tests/balance_manager_ordinal.rs
+++ b/core/src/balance/manager/tests/balance_manager_ordinal.rs
@@ -3164,7 +3164,7 @@ mod tests {
                 .as_ref()
                 .expect("in test")
                 .clone(),
-            Some(vec![order_ref]),
+            Some(&mut vec![order_ref].iter()),
         )
         .expect("in test");
 
@@ -3268,7 +3268,7 @@ mod tests {
                 .as_ref()
                 .expect("in test")
                 .clone(),
-            Some(vec![order_ref]),
+            Some(&mut vec![order_ref].iter()),
         )
         .expect("in test");
 
@@ -3386,7 +3386,7 @@ mod tests {
                 .as_ref()
                 .expect("in test")
                 .clone(),
-            Some(vec![order_ref]),
+            Some(&mut vec![order_ref].iter()),
         )
         .expect("in test");
 
@@ -3957,7 +3957,7 @@ mod tests {
                 .as_ref()
                 .expect("in test")
                 .clone(),
-            Some(vec![order_ref]),
+            Some(&mut vec![order_ref].iter()),
         )
         .expect("in test");
 
@@ -4096,7 +4096,7 @@ mod tests {
                 .as_ref()
                 .expect("in test")
                 .clone(),
-            Some(vec![order_ref_1, order_ref_2, order_ref_3]),
+            Some(&mut vec![order_ref_1, order_ref_2, order_ref_3].iter()),
         )
         .expect("in test");
 

--- a/examples/strategies/src/example_strategy.rs
+++ b/examples/strategies/src/example_strategy.rs
@@ -175,7 +175,7 @@ impl ExampleStrategy {
 
             let balance_manager = BalanceManager::clone_and_subtract_not_approved_data(
                 self.engine_context.balance_manager.clone(),
-                Some(orders),
+                Some(&mut orders.iter()),
             )
             .expect("ExampleStrategy::calc_trading_context_by_side: failed to clone and subtract not approved data for BalanceManager");
 


### PR DESCRIPTION
It's no needed vector of `OrderRef` now and can work with any iterator. That helps to not allocating order's vector for calling this method.