### PR TITLE
Implemented stop-loss orders for Binance

### DIFF
--- a/core/src/balance/changes/tests/calculator_tests_base.rs
+++ b/core/src/balance/changes/tests/calculator_tests_base.rs
@@ -6,9 +6,9 @@ pub mod tests {
     use mmb_domain::exchanges::symbol::{Precision, Symbol};
     use mmb_domain::market::{CurrencyCode, CurrencyPair, ExchangeAccountId};
     use mmb_domain::order::fill::{OrderFill, OrderFillType};
-    use mmb_domain::order::snapshot::{Amount, Price};
+    use mmb_domain::order::snapshot::{Amount, OrderOptions, Price};
     use mmb_domain::order::snapshot::{
-        ClientOrderFillId, ClientOrderId, OrderFillRole, OrderSide, OrderSnapshot, OrderType,
+        ClientOrderFillId, ClientOrderId, OrderFillRole, OrderSide, OrderSnapshot,
     };
     use mmb_utils::cancellation_token::CancellationToken;
     use mmb_utils::hashmap;
@@ -270,11 +270,10 @@ pub mod tests {
         ) -> OrderSnapshot {
             let mut order = OrderSnapshot::with_params(
                 ClientOrderId::unique_id(),
-                OrderType::Limit,
+                OrderOptions::limit(price),
                 None,
                 exchange_account_id,
                 currency_pair,
-                Some(price),
                 amount,
                 trade_side,
                 None,

--- a/core/src/balance/manager/balance_manager.rs
+++ b/core/src/balance/manager/balance_manager.rs
@@ -466,25 +466,19 @@ impl BalanceManager {
         if let Some(orders_to_subtract) = orders {
             let mut applied_orders = HashSet::new();
             for order in orders_to_subtract {
-                let (order_type, client_order_id, reservation_id, status) = order.fn_ref(|x| {
-                    (
-                        x.header.order_type,
-                        x.header.client_order_id.clone(),
-                        x.header.reservation_id,
-                        x.props.status,
-                    )
-                });
+                let client_order_id = order.client_order_id();
 
+                let status = order.status();
                 if status.is_finished() || status == OrderStatus::Creating {
                     continue;
                 }
 
-                if order_type == OrderType::Market {
+                if order.header().order_type == OrderType::Market {
                     bail!("Clone doesn't support market orders because we need to know the price")
                 }
 
                 if applied_orders.insert(client_order_id.clone()) {
-                    let reservation_id = match reservation_id {
+                    let reservation_id = match order.header().reservation_id {
                         Some(reservation_id) => reservation_id,
                         None => continue,
                     };

--- a/core/src/balance/manager/tests/balance_manager_base.rs
+++ b/core/src/balance/manager/tests/balance_manager_base.rs
@@ -13,10 +13,9 @@ use itertools::Itertools;
 use mmb_domain::events::{ExchangeBalance, ExchangeBalancesAndPositions};
 use mmb_domain::exchanges::symbol::Symbol;
 use mmb_domain::market::{CurrencyCode, CurrencyPair, ExchangeAccountId};
-use mmb_domain::order::snapshot::{Amount, Price};
+use mmb_domain::order::snapshot::{Amount, Price, UserOrder};
 use mmb_domain::order::snapshot::{
-    ClientOrderId, OrderExecutionType, OrderHeader, OrderSide, OrderSimpleProps, OrderSnapshot,
-    OrderType, ReservationId,
+    ClientOrderId, OrderHeader, OrderSide, OrderSimpleProps, OrderSnapshot, ReservationId,
 };
 use mmb_domain::position::DerivativePosition;
 use mockall_double::double;
@@ -242,26 +241,24 @@ impl BalanceManagerBase {
         order_side: OrderSide,
         reservation_id: ReservationId,
     ) -> OrderSnapshot {
-        self.create_order_by_amount(order_side, Some(dec!(0.2)), dec!(5), reservation_id)
+        self.create_order_by_amount(order_side, dec!(0.2), dec!(5), reservation_id)
     }
 
     pub fn create_order_by_amount(
         &mut self,
         order_side: OrderSide,
-        price: Option<Price>,
+        price: Price,
         amount: Amount,
         reservation_id: ReservationId,
     ) -> OrderSnapshot {
         let order_snapshot = OrderSnapshot {
-            header: OrderHeader::new(
+            header: OrderHeader::with_user_order(
                 ClientOrderId::new(format!("order{}", self.order_index).into()),
                 self.exchange_account_id_1,
                 self.symbol().currency_pair(),
-                OrderType::Limit,
                 order_side,
-                price,
                 amount,
-                OrderExecutionType::None,
+                UserOrder::limit(price),
                 Some(reservation_id),
                 None,
                 "balance_manager_base".into(),

--- a/core/src/exchanges/general/exchange.rs
+++ b/core/src/exchanges/general/exchange.rs
@@ -495,19 +495,18 @@ impl Exchange {
 
     pub(crate) fn add_event_on_order_change(
         &self,
-        order_ref: &OrderRef,
+        order: &OrderRef,
         event_type: OrderEventType,
     ) -> Result<()> {
         if let OrderEventType::CancelOrderSucceeded = event_type {
-            order_ref.fn_mut(|order| order.internal_props.was_cancellation_event_raised = true)
+            order.fn_mut(|order| order.internal_props.was_cancellation_event_raised = true)
         }
 
-        let (status, client_order_id) = order_ref.fn_ref(|x| (x.status(), x.client_order_id()));
-        if status.is_finished() {
-            let _ = self.orders.not_finished.remove(&client_order_id);
+        if order.is_finished() {
+            let _ = self.orders.not_finished.remove(&order.client_order_id());
         }
 
-        let event = ExchangeEvent::OrderEvent(OrderEvent::new(order_ref.clone(), event_type));
+        let event = ExchangeEvent::OrderEvent(OrderEvent::new(order.clone(), event_type));
         self.events_channel
             .send(event)
             .context("Unable to send event. Probably receiver is already dropped")?;

--- a/core/src/exchanges/general/order/cancel.rs
+++ b/core/src/exchanges/general/order/cancel.rs
@@ -49,8 +49,8 @@ impl Exchange {
         order: &OrderRef,
         cancellation_token: CancellationToken,
     ) -> Result<Option<CancelOrderResult>> {
-        let (status, client_order_id, exchange_order_id) =
-            order.fn_ref(|x| (x.status(), x.client_order_id(), x.exchange_order_id()));
+        let client_order_id = order.client_order_id();
+        let (status, exchange_order_id) = order.fn_ref(|x| (x.status(), x.exchange_order_id()));
         match status {
             OrderStatus::Canceled => {
                 log::info!(

--- a/core/src/exchanges/general/test_helper.rs
+++ b/core/src/exchanges/general/test_helper.rs
@@ -34,12 +34,9 @@ use mmb_domain::market::{
     CurrencyCode, CurrencyId, CurrencyPair, ExchangeAccountId, SpecificCurrencyPair,
 };
 use mmb_domain::order::pool::{OrderRef, OrdersPool};
-use mmb_domain::order::snapshot::{Amount, ExchangeOrderId, Price};
-use mmb_domain::order::snapshot::{
-    ClientOrderId, OrderInfo, OrderRole, OrderSide, OrderSnapshot, OrderType,
-};
+use mmb_domain::order::snapshot::{Amount, ExchangeOrderId, OrderOptions, Price};
+use mmb_domain::order::snapshot::{ClientOrderId, OrderInfo, OrderRole, OrderSide, OrderSnapshot};
 use mmb_domain::position::{ActivePosition, ClosedPosition};
-use parking_lot::RwLock;
 use rust_decimal_macros::dec;
 use tokio::sync::broadcast;
 use url::Url;
@@ -331,11 +328,10 @@ pub(crate) fn create_order_ref(
 ) -> OrderRef {
     let order = OrderSnapshot::with_params(
         client_order_id.clone(),
-        OrderType::Liquidation,
+        OrderOptions::liquidation(price),
         role,
         exchange_account_id,
         currency_pair,
-        Some(price),
         amount,
         side,
         None,
@@ -343,7 +339,7 @@ pub(crate) fn create_order_ref(
     );
 
     let order_pool = OrdersPool::new();
-    order_pool.add_snapshot_initial(Arc::new(RwLock::new(order)));
+    order_pool.add_snapshot_initial(&order);
     let order_ref = order_pool
         .cache_by_client_id
         .get(client_order_id)

--- a/core/src/exchanges/timeouts/more_or_equals_available_requests_count_trigger_scheduler.rs
+++ b/core/src/exchanges/timeouts/more_or_equals_available_requests_count_trigger_scheduler.rs
@@ -72,7 +72,7 @@ impl MoreOrEqualsAvailableRequestsCountTrigger {
             return;
         }
 
-        // Note: suppose that requests restriction same as in RequestsTimeoutManager (requests count in specified time period)
+        // NOTE: suppose that requests restriction same as in RequestsTimeoutManager (requests count in specified time period)
         // It logical dependency to RequestsTimeoutManager how calculate trigger time
         // var triggerTime = isGreater ? lastRequestTime : lastRequestTime + periodDuration;
         let trigger_time = last_request_time + period_duration;

--- a/core/src/exchanges/timeouts/requests_timeout_manager.rs
+++ b/core/src/exchanges/timeouts/requests_timeout_manager.rs
@@ -233,8 +233,8 @@ impl RequestsTimeoutManager {
         current_time: DateTime,
         cancellation_token: CancellationToken,
     ) -> (JoinHandle<FutureOutcome>, DateTime, Duration) {
-        // Note: calculation doesn't support request cancellation
-        // Note: suppose that exchange restriction work as your have n request on period and n request from beginning of next period and so on
+        // NOTE: calculation doesn't support request cancellation
+        // NOTE: suppose that exchange restriction work as your have n request on period and n request from beginning of next period and so on
 
         // Algorithm:
         // 1. We check: can we do request now

--- a/core/src/exchanges/traits.rs
+++ b/core/src/exchanges/traits.rs
@@ -119,12 +119,12 @@ pub trait ExchangeClient: Support {
 
     /// Must be implemented for derivative exchanges
     /// /// If exchange doesn't support futures the method must call panic (unimplemented!())
-    /// Note: we should get only open account positions
+    /// NOTE: we should get only open account positions
     async fn get_active_positions(&self) -> Result<Vec<ActivePosition>>;
 
     /// Getting only balance when spot and balance and positions when derivative
     /// Should get both balance and positions from single request if possible
-    /// Note: we expect all wallet currencies balances
+    /// NOTE: we expect all wallet currencies balances
     async fn get_balance_and_positions(&self) -> Result<ExchangeBalancesAndPositions>;
 
     /// # Params

--- a/core/src/statistic_service.rs
+++ b/core/src/statistic_service.rs
@@ -150,10 +150,7 @@ pub struct StatisticService {
 
 impl StatisticService {
     pub fn new() -> Arc<Self> {
-        Arc::new(Self {
-            statistic_service_state: Default::default(),
-            partially_filled_orders: Default::default(),
-        })
+        Default::default()
     }
 
     pub(crate) fn register_created_order(&self, market_account_id: MarketAccountId) {

--- a/mmb_utils/src/cancellation_token.rs
+++ b/mmb_utils/src/cancellation_token.rs
@@ -16,7 +16,7 @@ struct CancellationState {
 }
 
 /// Lightweight object for signalling about cancellation of operation
-/// Note: expected passing through methods by owning value with cloning if we need checking cancellation in many places
+/// NOTE: expected passing through methods by owning value with cloning if we need checking cancellation in many places
 #[derive(Default, Clone)]
 pub struct CancellationToken {
     state: Arc<CancellationState>,

--- a/visualization/vis_robot_integration/src/liquidity_order_book.rs
+++ b/visualization/vis_robot_integration/src/liquidity_order_book.rs
@@ -54,15 +54,16 @@ pub fn create_liquidity_order_book_snapshot(
         .not_finished
         .iter()
         .filter_map(|pair_ref| {
-            pair_ref.fn_ref(|x| match (x.props.status, x.source_price()) {
+            let header = pair_ref.header();
+            pair_ref.fn_ref(|x| match (x.status(), header.source_price) {
                 // save for visualization non-market orders
                 (OrderStatus::Created | OrderStatus::Canceling, Some(price)) => {
                     Some(LiquidityOrder {
-                        client_order_id: x.header.client_order_id.clone(),
-                        side: x.header.side,
+                        client_order_id: header.client_order_id.clone(),
+                        side: header.side,
                         price,
-                        amount: x.amount(),
-                        remaining_amount: x.amount() - x.filled_amount(),
+                        amount: header.amount,
+                        remaining_amount: header.amount - x.filled_amount(),
                     })
                 }
                 _ => None,


### PR DESCRIPTION
- Implemented stop-loss orders creation for Binance
- Changed interface for order placing on exchange
- Refactored `OrderRef`. Removed redundant `Arc` from `OrderHeader` and it moved out from `RwLock`
- Saving `OrderSnapshot` to DB instead of `OrderRef`